### PR TITLE
Only reveal mines on the board when game over.

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -108,28 +108,40 @@ var selectSpot = function(x, y){
     return {hitInfo: "land", win: checkForWin()};
 }
 
+var performSpotReveal = function(x, y, callback) {
+    isRevealed[y][x] = true;
+    var adjacentSpots = null;
+    var amountOfAdjMines = 0;
+    var isMine = gameBoard[y][x];
+    if (!isMine){
+        //If not a mine, determine adjacent mines
+        adjacentSpots = getAdjacentSpots(x, y);
+        amountOfAdjMines = calculateAdjacentMines(adjacentSpots);
+        adjMinesCount[y][x] = amountOfAdjMines;
+    }
+    if (callback) {
+        callback(isMine, amountOfAdjMines, adjacentSpots);
+    }
+}
+
 var revealSpot = function(x, y){
     if (isRevealed[y][x]) return; //don't reveal already revealed spot
-    isRevealed[y][x] = true;
-    if (!gameBoard[y][x]){
-        //If not a mine, determine adjacent mines
-        var adjacentSpots = getAdjacentSpots(x, y);
-        var amountOfAdjMines = calculateAdjacentMines(adjacentSpots);
-        //if mine count is 0, then recursively call revealSpot on all adjacent spots
-        if (amountOfAdjMines <= 0){
-            for (var i = 0; i < adjacentSpots.length; i++){
-                revealSpot(adjacentSpots[i].x, adjacentSpots[i].y);
+    performSpotReveal(x, y, function(isMine, amountOfAdjMines, adjacentSpots) {
+        if (!isMine) {
+            //if mine count is 0, then recursively call revealSpot on all adjacent spots
+            if (amountOfAdjMines <= 0){
+                for (var i = 0; i < adjacentSpots.length; i++){
+                    revealSpot(adjacentSpots[i].x, adjacentSpots[i].y);
+                }
+            }
+        } else {
+            for (var a = 0; a < boardWidth; a++){
+                for (var b = 0; b < boardHeight; b++){
+                    performSpotReveal(a, b, null);
+                }
             }
         }
-        adjMinesCount[y][x] = amountOfAdjMines;
-    }else{
-        //If a mine, reveal whole board
-        for (var a = 0; a < boardWidth; a++){
-            for (var b = 0; b < boardHeight; b++){
-                revealSpot(a, b);
-            }
-        }
-    }
+    });
 }
 
 var getAdjacentSpots = function(x, y){

--- a/client/game.js
+++ b/client/game.js
@@ -10,6 +10,7 @@ var amountOfMines;
 var didWin = false;
 var firstBlockClicked = false;
 var firstBlockCallbacks = [];
+var revealBoardOnLoss = false;
 
 var init = function(gameOptions){
     didWin = false;
@@ -137,7 +138,9 @@ var revealSpot = function(x, y){
         } else {
             for (var a = 0; a < boardWidth; a++){
                 for (var b = 0; b < boardHeight; b++){
-                    performSpotReveal(a, b, null);
+                    if (revealBoardOnLoss || gameBoard[b][a]) {
+                        performSpotReveal(a, b, null);
+                    }
                 }
             }
         }


### PR DESCRIPTION
If player clicks a mine, only reveal all mines on the board unless the bool revealBoardOnLoss is set to true, which will reveal all spots on the board.  
  
This PR also reduces redundant reveal calls on the board that have already been revealed when game over. Board spots are now revealed by calling performSpotReveal, and when game over is reached that function is called directly for each board spot instead of revealSpot to avoid unneeded recursion.  
  
For those who are curious, here is a little benchmark I did to see how many function calls were saved. A global counter was declared, set to 0, and incremented each time revealSpot was called on game over.
_old (without performSpotReveal):_ 40228 - (amount of mines I clicked on that session, I didn't keep track 😆 )
_new (with performSpotReveal):_ (amount of mines I clicked on that session) + 0 😄 