### PR TITLE
Update Pixi.js to 4.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First, ensure that a [Pixi.js](https://github.com/pixijs/pixi.js) binary and a [
 │   ├───pixi.js.map         (or pixi.min.js.map)        (@v4.3.0)  
 │   ├───filters.js          (or filters.min.js)         (@v1.0.6)  
 │   ├───filters.js.map      (or filters.min.js.map)     (@v1.0.6)  
-|   | **(Filters included in Pixi.js Filters that are currently used by MinesweeperClone)**
+│   ├ **(Filters included in Pixi.js Filters that are currently used by MinesweeperClone)**  
 │   ├───pixelate.js         (or pixelate.min.js)        (@v1.0.6)  
 │   ├───pixelate.js.map     (or pixelate.min.js.map)    (@v1.0.6)  
 │   ├───blur.js             (or blur.min.js)            (@v1.0.6)  

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Simple clone of the well-known Minesweeper game. Created using Javascript, Node.
 First, ensure that a [Pixi.js](https://github.com/pixijs/pixi.js) binary and a [Pixi.js filters](https://github.com/pixijs/pixi-filters) binary is available in a subdirectory titled "pixi". This is the setup used currently:
 
 ├───pixi  
-│   ├───pixi.js             [or pixi.min.js]            (@v4.3.0)  
-│   ├───pixi.js.map         [or pixi.min.js.map]        (@v4.3.0)  
-│   ├───filters.js          [or filters.min.js]         (@v1.0.6)  
-│   ├───filters.js.map      [or filters.min.js.map]     (@v1.0.6)  
+│   ├───pixi.js             (or pixi.min.js)            (@v4.3.0)  
+│   ├───pixi.js.map         (or pixi.min.js.map)        (@v4.3.0)  
+│   ├───filters.js          (or filters.min.js)         (@v1.0.6)  
+│   ├───filters.js.map      (or filters.min.js.map)     (@v1.0.6)  
 |   | **(Filters included in Pixi.js Filters that are currently used by MinesweeperClone)**
-│   ├───pixelate.js         [or pixelate.min.js]        (@v1.0.6)  
-│   ├───pixelate.js.map     [or pixelate.min.js.map]    (@v1.0.6)  
-│   ├───blur.js             [or blur.min.js]            (@v1.0.6)  
-│   ├───blur.js.map         [or blur.min.js.map]        (@v1.0.6)  
+│   ├───pixelate.js         (or pixelate.min.js)        (@v1.0.6)  
+│   ├───pixelate.js.map     (or pixelate.min.js.map)    (@v1.0.6)  
+│   ├───blur.js             (or blur.min.js)            (@v1.0.6)  
+│   ├───blur.js.map         (or blur.min.js.map)        (@v1.0.6)  
 
 Browserify is used to patch together all the js files linked via require into a single bundle.js file. To do this, run the following:
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,15 @@ Simple clone of the well-known Minesweeper game. Created using Javascript, Node.
 First, ensure that a [Pixi.js](https://github.com/pixijs/pixi.js) binary and a [Pixi.js filters](https://github.com/pixijs/pixi-filters) binary is available in a subdirectory titled "pixi". This is the setup used currently:
 
 ├───pixi  
-│   ├───pixi.js (@v4.1.0)  
-│   ├───filters.js (@v1.0.6)  
+│   ├───pixi.js             [or pixi.min.js]            (@v4.3.0)  
+│   ├───pixi.js.map         [or pixi.min.js.map]        (@v4.3.0)  
+│   ├───filters.js          [or filters.min.js]         (@v1.0.6)  
+│   ├───filters.js.map      [or filters.min.js.map]     (@v1.0.6)  
+|   | **(Filters included in Pixi.js Filters that are currently used by MinesweeperClone)**
+│   ├───pixelate.js         [or pixelate.min.js]        (@v1.0.6)  
+│   ├───pixelate.js.map     [or pixelate.min.js.map]    (@v1.0.6)  
+│   ├───blur.js             [or blur.min.js]            (@v1.0.6)  
+│   ├───blur.js.map         [or blur.min.js.map]        (@v1.0.6)  
 
 Browserify is used to patch together all the js files linked via require into a single bundle.js file. To do this, run the following:
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ First, ensure that a [Pixi.js](https://github.com/pixijs/pixi.js) binary and a [
 ├───pixi  
 │   ├───pixi.js             (or pixi.min.js)            (@v4.3.0)  
 │   ├───pixi.js.map         (or pixi.min.js.map)        (@v4.3.0)  
+│   ├ **(Can either include entire filters.js or include specific filters separately)**  
 │   ├───filters.js          (or filters.min.js)         (@v1.0.6)  
 │   ├───filters.js.map      (or filters.min.js.map)     (@v1.0.6)  
-│   ├ **(Filters included in Pixi.js Filters that are currently used by MinesweeperClone)**  
+│   ├ **(Filters included as separate .js files that are currently used by MinesweeperClone)**  
 │   ├───pixelate.js         (or pixelate.min.js)        (@v1.0.6)  
 │   ├───pixelate.js.map     (or pixelate.min.js.map)    (@v1.0.6)  
-│   ├───blur.js             (or blur.min.js)            (@v1.0.6)  
-│   ├───blur.js.map         (or blur.min.js.map)        (@v1.0.6)  
 
 Browserify is used to patch together all the js files linked via require into a single bundle.js file. To do this, run the following:
 


### PR DESCRIPTION
Pixi.js update [4.2.1](https://github.com/pixijs/pixi.js/releases/tag/v4.2.1) fixed an issue where mouse events wouldn't fire on Chrome and Edge. Bumped Pixi.js version to [4.3.0](https://github.com/pixijs/pixi.js/releases/tag/v4.3.0).

https://github.com/pixijs/pixi.js/pull/3233