### PR TITLE
Add a script to download latest pixi.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 bundle.js
 
 # Pixi.js
-*pixi*
+*pixi*/

--- a/scripts/download-latest-pixi.sh
+++ b/scripts/download-latest-pixi.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/sh
+
+mkdir pixi
+cd pixi
+curl --remote-name-all http://pixijs.download/release/pixi{.js,.js.map}
+if [ $# -gt 0 ] && { [ "$1" = "separate" ] || [ "$1" = "s" ]; }; then
+    curl --remote-name-all https://raw.githubusercontent.com/pixijs/pixi-filters/publish/bin/pixelate{.js,.js.map}
+else
+    curl --remote-name-all https://raw.githubusercontent.com/pixijs/pixi-filters/publish/bin/filters{.js,.js.map}
+fi
+cd ..


### PR DESCRIPTION
This sh script will install the latest version of pixi.js as well as the pixi.js filters. A command line argument "**s**eparate" can be passed to download the separate filter .js files that are required instead of the entire filter.js.