### PR TITLE
Fix audio stopping after returning from external link on iOS PWA (COT-93)

### DIFF
--- a/src/manager/audio.ts
+++ b/src/manager/audio.ts
@@ -123,13 +123,11 @@ export class AudioManager {
             return;
         }
 
-        const resolvedSound = sound;
-
         let finalVolume = this.soundEffectsVolume;
 
         if (typeof settings !== 'undefined') {
             if (typeof settings.seek !== 'undefined') {
-                resolvedSound.seek(settings.seek);
+                sound.seek(settings.seek);
             }
             if (typeof settings.volume !== 'undefined') {
                 // Apply both the per-sound volume and the global volume
@@ -137,7 +135,7 @@ export class AudioManager {
             }
         }
 
-        resolvedSound.volume(finalVolume);
-        resolvedSound.play();
+        sound.volume(finalVolume);
+        sound.play();
     }
 }

--- a/src/manager/audio.ts
+++ b/src/manager/audio.ts
@@ -34,6 +34,7 @@ export class AudioManager {
 
     private soundEffectsEnabled: boolean;
     private soundEffectsVolume: number;
+    private needsAudioResume: boolean = false;
 
     constructor(assetManager: AssetManager) {
         this.assetManager = assetManager;
@@ -64,37 +65,45 @@ export class AudioManager {
     }
 
     /**
-     * Sets up event listeners to resume AudioContext when the page becomes visible again.
-     * This is necessary for iOS PWAs where the AudioContext gets suspended when the app
-     * goes to background and needs to be explicitly resumed.
-     * NOTE: Might not need this anymore after https://github.com/goldfire/howler.js/pull/1770 is merged.
+     * Sets up event listeners to recover audio after iOS suspends the AudioContext when
+     * the user switches to a native app (e.g. tapping a link that opens the GitHub app).
+     *
+     * The problem: when a native app takes focus, iOS suspends the WebAudio AudioContext.
+     * Howler's play() check is `Howler.state === 'running' && ctx.state !== 'interrupted'`.
+     * Since iOS reports the suspended context as 'suspended' (not 'interrupted'), Howler
+     * sees this as fine and tries to play immediately on a suspended context. The buffer
+     * source starts but never produces audio; the end timer fires and the sound is dropped.
+     *
+     * The fix: on the first user gesture after the page was hidden, override Howler's
+     * internal state to 'suspended' so that its _autoResume() takes the correct code path:
+     * it resumes the AudioContext and emits the 'resume' event that pending sounds wait on.
+     * NOTE: This workaround can be removed if https://github.com/goldfire/howler.js/pull/1770
+     * is ever merged and released.
      */
     private setupAudioContextResumeHandlers() {
         document.addEventListener('visibilitychange', () => {
-            if (document.visibilityState === 'visible') {
-                this.resumeAudioContext();
+            if (document.visibilityState === 'hidden') {
+                this.needsAudioResume = true;
             }
         });
 
-        // On iOS, AudioContext.resume() must be called within a user gesture.
-        // When returning from an external link opened via target="_blank" (e.g. Safari),
-        // visibilitychange fires but is not considered a user gesture, so resume() is
-        // silently blocked. Resuming on the next user interaction ensures audio works again.
-        const resumeOnInteraction = () => this.resumeAudioContext();
+        const resumeOnInteraction = () => {
+            if (!this.needsAudioResume) return;
+            this.needsAudioResume = false;
+
+            const ctx = Howler.ctx;
+            if (!ctx || ctx.state === 'running') return;
+
+            // Force Howler's internal state to 'suspended' so _autoResume() takes the
+            // branch that calls ctx.resume() and emits 'resume' to all queued Howl sounds.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (Howler as any).state = 'suspended';
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (Howler as any)._autoResume();
+        };
+
         document.addEventListener('touchstart', resumeOnInteraction, { passive: true });
         document.addEventListener('click', resumeOnInteraction);
-    }
-
-    /**
-     * Attempts to resume the AudioContext if it's not running.
-     * If the AudioContext is already running, this is a no-op.
-     */
-    private resumeAudioContext() {
-        if (Howler.ctx && Howler.ctx.state !== 'running') {
-            Howler.ctx.resume().catch((err) => {
-                console.warn('Failed to resume audio context:', err);
-            });
-        }
     }
 
     playSoundEffect(soundEffect: SoundEffect, settings?: SoundSettings) {
@@ -116,39 +125,19 @@ export class AudioManager {
 
         const resolvedSound = sound;
 
-        const play = () => {
-            // Calculate final volume
-            let finalVolume = this.soundEffectsVolume;
+        let finalVolume = this.soundEffectsVolume;
 
-            if (typeof settings !== 'undefined') {
-                if (typeof settings.seek !== 'undefined') {
-                    resolvedSound.seek(settings.seek);
-                }
-                if (typeof settings.volume !== 'undefined') {
-                    // Apply both the per-sound volume and the global volume
-                    finalVolume = settings.volume * this.soundEffectsVolume;
-                }
+        if (typeof settings !== 'undefined') {
+            if (typeof settings.seek !== 'undefined') {
+                resolvedSound.seek(settings.seek);
             }
-
-            resolvedSound.volume(finalVolume);
-            resolvedSound.play();
-        };
-
-        // If the AudioContext is suspended (e.g., iOS suspends it after switching tabs),
-        // resume it before playing. AudioContext.resume() resolves asynchronously, so we
-        // defer playback to the .then() callback. This is called within a user gesture
-        // (touchend/click handler), so iOS will allow the resume to succeed.
-        if (Howler.ctx && Howler.ctx.state !== 'running') {
-            Howler.ctx
-                .resume()
-                .then(play)
-                .catch((err) => {
-                    console.warn('Failed to resume audio context:', err);
-                    play();
-                });
-            return;
+            if (typeof settings.volume !== 'undefined') {
+                // Apply both the per-sound volume and the global volume
+                finalVolume = settings.volume * this.soundEffectsVolume;
+            }
         }
 
-        play();
+        resolvedSound.volume(finalVolume);
+        resolvedSound.play();
     }
 }

--- a/src/manager/audio.ts
+++ b/src/manager/audio.ts
@@ -65,20 +65,17 @@ export class AudioManager {
     }
 
     /**
-     * Sets up event listeners to recover audio after iOS suspends the AudioContext when
-     * the user switches to a native app (e.g. tapping a link that opens the GitHub app).
+     * Recovers audio after iOS suspends the AudioContext when the user switches to a
+     * native app. iOS sets ctx.state to 'suspended' but Howler has no listener for
+     * external state changes, so Howler.state stays 'running'. This mismatch causes
+     * _autoResume() to no-op and play() to fire immediately on a dead context, silently
+     * dropping sounds.
      *
-     * The problem: when a native app takes focus, iOS suspends the WebAudio AudioContext.
-     * Howler's play() check is `Howler.state === 'running' && ctx.state !== 'interrupted'`.
-     * Since iOS reports the suspended context as 'suspended' (not 'interrupted'), Howler
-     * sees this as fine and tries to play immediately on a suspended context. The buffer
-     * source starts but never produces audio; the end timer fires and the sound is dropped.
+     * Fix: on the first gesture after returning, sync Howler.state to 'suspended' so
+     * _autoResume() takes the branch that calls ctx.resume() and emits 'resume' to all
+     * Howls — including any already-playing sounds like looping background music.
      *
-     * The fix: on the first user gesture after the page was hidden, override Howler's
-     * internal state to 'suspended' so that its _autoResume() takes the correct code path:
-     * it resumes the AudioContext and emits the 'resume' event that pending sounds wait on.
-     * NOTE: This workaround can be removed if https://github.com/goldfire/howler.js/pull/1770
-     * is ever merged and released.
+     * NOTE: Remove if https://github.com/goldfire/howler.js/pull/1770 is ever merged.
      */
     private setupAudioContextResumeHandlers() {
         document.addEventListener('visibilitychange', () => {
@@ -94,8 +91,8 @@ export class AudioManager {
             const ctx = Howler.ctx;
             if (!ctx || ctx.state === 'running') return;
 
-            // Force Howler's internal state to 'suspended' so _autoResume() takes the
-            // branch that calls ctx.resume() and emits 'resume' to all queued Howl sounds.
+            // Sync Howler's internal state to match the real AudioContext state so that
+            // _autoResume() enters the branch that calls ctx.resume() and emits 'resume'.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (Howler as any).state = 'suspended';
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/manager/audio.ts
+++ b/src/manager/audio.ts
@@ -115,11 +115,8 @@ export class AudioManager {
             }
         };
 
-        document.addEventListener('touchstart', resumeOnInteraction, {
-            passive: true,
-            capture: true,
-        });
-        document.addEventListener('click', resumeOnInteraction, { capture: true });
+        document.addEventListener('touchstart', resumeOnInteraction, { passive: true });
+        document.addEventListener('click', resumeOnInteraction);
     }
 
     playSoundEffect(soundEffect: SoundEffect, settings?: SoundSettings) {

--- a/src/manager/audio.ts
+++ b/src/manager/audio.ts
@@ -75,6 +75,14 @@ export class AudioManager {
                 this.resumeAudioContext();
             }
         });
+
+        // On iOS, AudioContext.resume() must be called within a user gesture.
+        // When returning from an external link opened via target="_blank" (e.g. Safari),
+        // visibilitychange fires but is not considered a user gesture, so resume() is
+        // silently blocked. Resuming on the next user interaction ensures audio works again.
+        const resumeOnInteraction = () => this.resumeAudioContext();
+        document.addEventListener('touchstart', resumeOnInteraction, { passive: true });
+        document.addEventListener('click', resumeOnInteraction);
     }
 
     /**

--- a/src/manager/audio.ts
+++ b/src/manager/audio.ts
@@ -115,8 +115,11 @@ export class AudioManager {
             }
         };
 
-        document.addEventListener('touchstart', resumeOnInteraction, { passive: true });
-        document.addEventListener('click', resumeOnInteraction);
+        document.addEventListener('touchstart', resumeOnInteraction, {
+            passive: true,
+            capture: true,
+        });
+        document.addEventListener('click', resumeOnInteraction, { capture: true });
     }
 
     playSoundEffect(soundEffect: SoundEffect, settings?: SoundSettings) {

--- a/src/manager/audio.ts
+++ b/src/manager/audio.ts
@@ -98,7 +98,8 @@ export class AudioManager {
 
             if ('state' in howler && typeof howler._autoResume === 'function') {
                 // Sync Howler's internal state to match the real AudioContext state so that
-                // _autoResume() enters the branch that calls ctx.resume() and emits 'resume'.
+                // when _autoResume() is called, it will take the correct path inside that function
+                // to call ctx.resume() and emit 'resume' to all registered Howls.
                 howler.state = 'suspended';
                 howler._autoResume();
                 this.needsAudioResume = false;

--- a/src/manager/audio.ts
+++ b/src/manager/audio.ts
@@ -114,20 +114,41 @@ export class AudioManager {
             return;
         }
 
-        // Calculate final volume
-        let finalVolume = this.soundEffectsVolume;
+        const resolvedSound = sound;
 
-        if (typeof settings !== 'undefined') {
-            if (typeof settings.seek !== 'undefined') {
-                sound.seek(settings.seek);
+        const play = () => {
+            // Calculate final volume
+            let finalVolume = this.soundEffectsVolume;
+
+            if (typeof settings !== 'undefined') {
+                if (typeof settings.seek !== 'undefined') {
+                    resolvedSound.seek(settings.seek);
+                }
+                if (typeof settings.volume !== 'undefined') {
+                    // Apply both the per-sound volume and the global volume
+                    finalVolume = settings.volume * this.soundEffectsVolume;
+                }
             }
-            if (typeof settings.volume !== 'undefined') {
-                // Apply both the per-sound volume and the global volume
-                finalVolume = settings.volume * this.soundEffectsVolume;
-            }
+
+            resolvedSound.volume(finalVolume);
+            resolvedSound.play();
+        };
+
+        // If the AudioContext is suspended (e.g., iOS suspends it after switching tabs),
+        // resume it before playing. AudioContext.resume() resolves asynchronously, so we
+        // defer playback to the .then() callback. This is called within a user gesture
+        // (touchend/click handler), so iOS will allow the resume to succeed.
+        if (Howler.ctx && Howler.ctx.state !== 'running') {
+            Howler.ctx
+                .resume()
+                .then(play)
+                .catch((err) => {
+                    console.warn('Failed to resume audio context:', err);
+                    play();
+                });
+            return;
         }
 
-        sound.volume(finalVolume);
-        sound.play();
+        play();
     }
 }

--- a/src/manager/audio.ts
+++ b/src/manager/audio.ts
@@ -86,17 +86,32 @@ export class AudioManager {
 
         const resumeOnInteraction = () => {
             if (!this.needsAudioResume) return;
-            this.needsAudioResume = false;
 
             const ctx = Howler.ctx;
-            if (!ctx || ctx.state === 'running') return;
+            if (!ctx || ctx.state === 'running') {
+                this.needsAudioResume = false;
+                return;
+            }
 
-            // Sync Howler's internal state to match the real AudioContext state so that
-            // _autoResume() enters the branch that calls ctx.resume() and emits 'resume'.
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (Howler as any).state = 'suspended';
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (Howler as any)._autoResume();
+            type HowlerInternals = { state?: string; _autoResume?: () => void };
+            const howler = Howler as unknown as HowlerInternals;
+
+            if ('state' in howler && typeof howler._autoResume === 'function') {
+                // Sync Howler's internal state to match the real AudioContext state so that
+                // _autoResume() enters the branch that calls ctx.resume() and emits 'resume'.
+                howler.state = 'suspended';
+                howler._autoResume();
+                this.needsAudioResume = false;
+            } else {
+                // Howler internals unavailable; fall back to resuming the AudioContext directly.
+                ctx.resume()
+                    .then(() => {
+                        this.needsAudioResume = false;
+                    })
+                    .catch((err) => {
+                        console.warn('Failed to resume audio context:', err);
+                    });
+            }
         };
 
         document.addEventListener('touchstart', resumeOnInteraction, { passive: true });

--- a/test/audio.test.ts
+++ b/test/audio.test.ts
@@ -170,24 +170,18 @@ describe('AudioManager', () => {
             consoleErrorSpy.mockRestore();
         });
 
-        it('should defer playback until AudioContext is resumed when suspended', async () => {
+        it('should play sound even when AudioContext is suspended', () => {
             const playSpy = jest.spyOn(mockSound, 'play');
-            const mockResume = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
             (
                 Howler as {
                     ctx: { state: string; resume: () => Promise<void> } | null;
                 }
             ).ctx = {
                 state: 'suspended',
-                resume: mockResume,
+                resume: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
             };
 
             audioManager.playSoundEffect(SoundEffect.Click);
-
-            expect(mockResume).toHaveBeenCalled();
-            expect(playSpy).not.toHaveBeenCalled(); // not yet — waiting for resume
-
-            await Promise.resolve(); // flush the resume promise
 
             expect(playSpy).toHaveBeenCalled();
         });
@@ -210,35 +204,37 @@ describe('AudioManager', () => {
             expect(playSpy).toHaveBeenCalled();
         });
 
-        it('should play sound even if AudioContext resume fails', async () => {
+        it('should play sound even when AudioContext resume would fail', () => {
             const playSpy = jest.spyOn(mockSound, 'play');
-            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-            const mockError = new Error('Resume failed');
-            const mockResume = jest.fn<() => Promise<void>>().mockRejectedValue(mockError);
             (
                 Howler as {
                     ctx: { state: string; resume: () => Promise<void> } | null;
                 }
             ).ctx = {
                 state: 'suspended',
-                resume: mockResume,
+                resume: jest
+                    .fn<() => Promise<void>>()
+                    .mockRejectedValue(new Error('Resume failed')),
             };
 
             audioManager.playSoundEffect(SoundEffect.Click);
 
-            await Promise.resolve(); // flush the rejected resume promise
-            await Promise.resolve(); // flush the .catch() handler
-
-            expect(consoleWarnSpy).toHaveBeenCalledWith(
-                'Failed to resume audio context:',
-                mockError,
-            );
             expect(playSpy).toHaveBeenCalled();
-            consoleWarnSpy.mockRestore();
         });
     });
 
     describe('AudioContext resume handlers', () => {
+        const triggerHiddenVisibilityChange = () => {
+            Object.defineProperty(mockDocument, 'visibilityState', {
+                value: 'hidden',
+                configurable: true,
+            });
+            const handler = (
+                mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
+            ).mock.calls.find((call) => call[0] === 'visibilitychange')?.[1] as () => void;
+            handler();
+        };
+
         it('should set up event listener for visibility change', () => {
             // This should have been called in the constructor
             expect(mockDocument.addEventListener).toHaveBeenCalledWith(
@@ -273,6 +269,8 @@ describe('AudioManager', () => {
                 resume: mockResume,
             };
 
+            triggerHiddenVisibilityChange();
+
             const touchstartHandler = (
                 mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
             ).mock.calls.find((call) => call[0] === 'touchstart')?.[1] as () => void;
@@ -293,6 +291,8 @@ describe('AudioManager', () => {
                 resume: mockResume,
             };
 
+            triggerHiddenVisibilityChange();
+
             const clickHandler = (
                 mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
             ).mock.calls.find((call) => call[0] === 'click')?.[1] as () => void;
@@ -302,7 +302,7 @@ describe('AudioManager', () => {
             expect(mockResume).toHaveBeenCalled();
         });
 
-        it('should resume audio context when it is not running on visibility change', () => {
+        it('should resume audio context on next gesture after page was hidden with suspended context', () => {
             const mockResume = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
             (
                 Howler as {
@@ -313,18 +313,13 @@ describe('AudioManager', () => {
                 resume: mockResume,
             };
 
-            // Simulate visibility change
-            const visibilityChangeHandler = (
+            triggerHiddenVisibilityChange();
+
+            const clickHandler = (
                 mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
-            ).mock.calls.find((call) => call[0] === 'visibilitychange')?.[1] as () => void;
+            ).mock.calls.find((call) => call[0] === 'click')?.[1] as () => void;
 
-            // Mock document.visibilityState
-            Object.defineProperty(mockDocument, 'visibilityState', {
-                value: 'visible',
-                configurable: true,
-            });
-
-            visibilityChangeHandler();
+            clickHandler();
 
             expect(mockResume).toHaveBeenCalled();
         });
@@ -392,19 +387,16 @@ describe('AudioManager', () => {
                 resume: mockResume,
             };
 
-            // Simulate visibility change
-            const visibilityChangeHandler = (
+            triggerHiddenVisibilityChange();
+
+            const clickHandler = (
                 mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
-            ).mock.calls.find((call) => call[0] === 'visibilitychange')?.[1] as () => void;
+            ).mock.calls.find((call) => call[0] === 'click')?.[1] as () => void;
 
-            Object.defineProperty(mockDocument, 'visibilityState', {
-                value: 'visible',
-                configurable: true,
-            });
-
-            visibilityChangeHandler();
+            clickHandler();
 
             // Flush the microtask queue so that the rejected resume's .catch() handler can run.
+            await Promise.resolve();
             await Promise.resolve();
 
             expect(consoleWarnSpy).toHaveBeenCalledWith(

--- a/test/audio.test.ts
+++ b/test/audio.test.ts
@@ -169,6 +169,73 @@ describe('AudioManager', () => {
             expect(consoleErrorSpy).toHaveBeenCalledWith('Sound not loaded:', 'click');
             consoleErrorSpy.mockRestore();
         });
+
+        it('should defer playback until AudioContext is resumed when suspended', async () => {
+            const playSpy = jest.spyOn(mockSound, 'play');
+            const mockResume = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+            (
+                Howler as {
+                    ctx: { state: string; resume: () => Promise<void> } | null;
+                }
+            ).ctx = {
+                state: 'suspended',
+                resume: mockResume,
+            };
+
+            audioManager.playSoundEffect(SoundEffect.Click);
+
+            expect(mockResume).toHaveBeenCalled();
+            expect(playSpy).not.toHaveBeenCalled(); // not yet — waiting for resume
+
+            await Promise.resolve(); // flush the resume promise
+
+            expect(playSpy).toHaveBeenCalled();
+        });
+
+        it('should play sound immediately when AudioContext is already running', () => {
+            const playSpy = jest.spyOn(mockSound, 'play');
+            const mockResume = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+            (
+                Howler as {
+                    ctx: { state: string; resume: () => Promise<void> } | null;
+                }
+            ).ctx = {
+                state: 'running',
+                resume: mockResume,
+            };
+
+            audioManager.playSoundEffect(SoundEffect.Click);
+
+            expect(mockResume).not.toHaveBeenCalled();
+            expect(playSpy).toHaveBeenCalled();
+        });
+
+        it('should play sound even if AudioContext resume fails', async () => {
+            const playSpy = jest.spyOn(mockSound, 'play');
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+            const mockError = new Error('Resume failed');
+            const mockResume = jest.fn<() => Promise<void>>().mockRejectedValue(mockError);
+            (
+                Howler as {
+                    ctx: { state: string; resume: () => Promise<void> } | null;
+                }
+            ).ctx = {
+                state: 'suspended',
+                resume: mockResume,
+            };
+
+            audioManager.playSoundEffect(SoundEffect.Click);
+
+            await Promise.resolve(); // flush the rejected resume promise
+            await Promise.resolve(); // flush the .catch() handler
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                'Failed to resume audio context:',
+                mockError,
+            );
+            expect(playSpy).toHaveBeenCalled();
+            consoleWarnSpy.mockRestore();
+        });
     });
 
     describe('AudioContext resume handlers', () => {

--- a/test/audio.test.ts
+++ b/test/audio.test.ts
@@ -243,19 +243,18 @@ describe('AudioManager', () => {
             );
         });
 
-        it('should set up touchstart event listener in capture phase', () => {
+        it('should set up touchstart event listener', () => {
             expect(mockDocument.addEventListener).toHaveBeenCalledWith(
                 'touchstart',
                 expect.any(Function),
-                { passive: true, capture: true },
+                { passive: true },
             );
         });
 
-        it('should set up click event listener in capture phase', () => {
+        it('should set up click event listener', () => {
             expect(mockDocument.addEventListener).toHaveBeenCalledWith(
                 'click',
                 expect.any(Function),
-                { capture: true },
             );
         });
 

--- a/test/audio.test.ts
+++ b/test/audio.test.ts
@@ -180,6 +180,61 @@ describe('AudioManager', () => {
             );
         });
 
+        it('should set up touchstart event listener', () => {
+            expect(mockDocument.addEventListener).toHaveBeenCalledWith(
+                'touchstart',
+                expect.any(Function),
+                { passive: true },
+            );
+        });
+
+        it('should set up click event listener', () => {
+            expect(mockDocument.addEventListener).toHaveBeenCalledWith(
+                'click',
+                expect.any(Function),
+            );
+        });
+
+        it('should resume audio context on touchstart when suspended', () => {
+            const mockResume = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+            (
+                Howler as {
+                    ctx: { state: string; resume: () => Promise<void> } | null;
+                }
+            ).ctx = {
+                state: 'suspended',
+                resume: mockResume,
+            };
+
+            const touchstartHandler = (
+                mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
+            ).mock.calls.find((call) => call[0] === 'touchstart')?.[1] as () => void;
+
+            touchstartHandler();
+
+            expect(mockResume).toHaveBeenCalled();
+        });
+
+        it('should resume audio context on click when suspended', () => {
+            const mockResume = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+            (
+                Howler as {
+                    ctx: { state: string; resume: () => Promise<void> } | null;
+                }
+            ).ctx = {
+                state: 'suspended',
+                resume: mockResume,
+            };
+
+            const clickHandler = (
+                mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
+            ).mock.calls.find((call) => call[0] === 'click')?.[1] as () => void;
+
+            clickHandler();
+
+            expect(mockResume).toHaveBeenCalled();
+        });
+
         it('should resume audio context when it is not running on visibility change', () => {
             const mockResume = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
             (

--- a/test/audio.test.ts
+++ b/test/audio.test.ts
@@ -243,18 +243,19 @@ describe('AudioManager', () => {
             );
         });
 
-        it('should set up touchstart event listener', () => {
+        it('should set up touchstart event listener in capture phase', () => {
             expect(mockDocument.addEventListener).toHaveBeenCalledWith(
                 'touchstart',
                 expect.any(Function),
-                { passive: true },
+                { passive: true, capture: true },
             );
         });
 
-        it('should set up click event listener', () => {
+        it('should set up click event listener in capture phase', () => {
             expect(mockDocument.addEventListener).toHaveBeenCalledWith(
                 'click',
                 expect.any(Function),
+                { capture: true },
             );
         });
 

--- a/test/audio.test.ts
+++ b/test/audio.test.ts
@@ -302,28 +302,6 @@ describe('AudioManager', () => {
             expect(mockResume).toHaveBeenCalled();
         });
 
-        it('should resume audio context on next gesture after page was hidden with suspended context', () => {
-            const mockResume = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
-            (
-                Howler as {
-                    ctx: { state: string; resume: () => Promise<void> } | null;
-                }
-            ).ctx = {
-                state: 'suspended',
-                resume: mockResume,
-            };
-
-            triggerHiddenVisibilityChange();
-
-            const clickHandler = (
-                mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
-            ).mock.calls.find((call) => call[0] === 'click')?.[1] as () => void;
-
-            clickHandler();
-
-            expect(mockResume).toHaveBeenCalled();
-        });
-
         it('should not resume audio context when it is already running', () => {
             const mockResume = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
             (
@@ -357,19 +335,15 @@ describe('AudioManager', () => {
                 }
             ).ctx = null;
 
-            // Simulate visibility change
-            const visibilityChangeHandler = (
-                mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
-            ).mock.calls.find((call) => call[0] === 'visibilitychange')?.[1] as () => void;
-
-            Object.defineProperty(mockDocument, 'visibilityState', {
-                value: 'visible',
-                configurable: true,
-            });
-
             // This should not throw
             expect(() => {
-                visibilityChangeHandler();
+                triggerHiddenVisibilityChange();
+
+                const clickHandler = (
+                    mockDocument.addEventListener as jest.Mock<DocumentAddEventListener>
+                ).mock.calls.find((call) => call[0] === 'click')?.[1] as () => void;
+
+                clickHandler();
             }).not.toThrow();
         });
 


### PR DESCRIPTION
On iOS, AudioContext.resume() must be called within a user gesture. When
returning from a target="_blank" link (e.g. the commit hash GitHub link),
visibilitychange fires but is not a user gesture, so resume() is silently
blocked. Add touchstart and click listeners so the AudioContext is resumed
on the next user interaction.

https://claude.ai/code/session_01AxhMF8dKAg1PpMfVSep7AJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio resume is deferred after the app is backgrounded and will resume on the next user touch/click; playback proceeds even if resume fails.  
  * Per-sound playback correctly applies seek position and computed final volume at play time.

* **Tests**
  * Added tests covering resume deferral, gesture listener registration (including passive touch), visibility-change handling, and resume error/resilience scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->