### PR TITLE
Fix stack overflow when recursively revealing tiles on board sizes 100x100 or greater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,6 @@ jobs:
         run: pnpm -v
       - name: Run pnpm CI install
         run: pnpm install
-      - name: Run type check
-        run: pnpm run type-check:test
-      - name: Run lint
-        run: pnpm run lint
-      - name: Run format check
-        run: pnpm run format:check
       - name: Run test
         run: pnpm run test-ci
       - name: Upload test results

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,26 @@
+name: Code Quality
+on: [push]
+jobs:
+  code-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Checking out ${{ github.ref }} from ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v6
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - name: Run pnpm CI install
+        run: pnpm install
+      - name: Run type check
+        run: pnpm run type-check:test
+      - name: Run lint
+        run: pnpm run lint
+      - name: Run format check
+        run: pnpm run format:check

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --config ./.prettierrc --write .",
     "format:check": "prettier --config ./.prettierrc --check .",
     "type-check": "tsc",
-    "type-check:test": "tsc -p tsconfig.test.json",
+    "type-check:test": "tsc -p tsconfig.test.json && tsc -p cypress/tsconfig.json",
     "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "test-ci": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --ci",
     "cypress": "cypress",

--- a/src/game.ts
+++ b/src/game.ts
@@ -355,14 +355,12 @@ export const selectAdjacentSpots = function (x: number, y: number) {
                 gameState.board[adjacentSpots[i].y][adjacentSpots[i].x].isLosingSpot = true;
             }
         }
-        revealMultiple(adjacentSpots).then((res) => {
-            if (res) {
-                console.log('At least one block was revealed here');
-                eventHandler({ type: 'reveal', data: { x, y } });
-            } else {
-                console.log('No new blocks were revealed');
-            }
-        });
+        if (revealMultiple(adjacentSpots)) {
+            console.log('At least one block was revealed here');
+            eventHandler({ type: 'reveal', data: { x, y } });
+        } else {
+            console.log('No new blocks were revealed');
+        }
     }
     if (doesMineExist) {
         gameState.ended = true;
@@ -405,60 +403,59 @@ const performSpotReveal = function (x: number, y: number, callback?: SpotRevealC
     if (callback) {
         callback(isMine, amountOfAdjMines, adjacentSpots);
     }
+    return {
+        isMine,
+        amountOfAdjMines,
+        adjacentSpots,
+    };
 };
 
-const revealSpot: (x: number, y: number) => Promise<boolean> = function (x: number, y: number) {
-    return new Promise((resolve) => {
-        // Don't reveal already revealed spot
-        if (gameState.board[y][x].isRevealed) {
-            resolve(false);
-            return;
+const revealSpot: (x: number, y: number) => boolean = function (x: number, y: number) {
+    const queue = [{x, y}];
+    const visited = new Set();
+
+    while (queue.length > 0) {
+        const coords = queue.shift()!;
+        const coordsStr = `${coords.x},${coords.y}`;
+        if (visited.has(coordsStr)) {
+            continue;
         }
-        performSpotReveal(
-            x,
-            y,
-            function (
-                isMine: boolean,
-                amountOfAdjMines: number,
-                adjacentSpots: Array<MineBlock> | null,
-            ) {
-                if (!isMine) {
-                    // If mine count is 0, then recursively call revealSpot on all adjacent spots that are not flagged
-                    if (amountOfAdjMines <= 0) {
-                        revealMultiple(adjacentSpots?.filter((spot) => !spot.isFlagged) ?? []);
-                    }
-                } else {
-                    for (let a = 0; a < gameState.gameOptions.boardWidth; a++) {
-                        for (let b = 0; b < gameState.gameOptions.boardHeight; b++) {
-                            if (
-                                gameState.gameOptions.revealBoardOnLoss ||
-                                gameState.board[b][a].isMine
-                            ) {
-                                performSpotReveal(a, b);
-                            }
-                        }
+
+        const {isMine, amountOfAdjMines, adjacentSpots} = performSpotReveal(coords.x, coords.y);
+
+        if (!isMine) {
+            if (amountOfAdjMines <= 0) {
+                const toAdd = adjacentSpots?.filter(spot => !spot.isFlagged) ?? [];
+                queue.push(...toAdd.map(spot => ({x: spot.x, y: spot.y})));
+            }
+        } else {
+            for (let a = 0; a < gameState.gameOptions.boardWidth; a++) {
+                for (let b = 0; b < gameState.gameOptions.boardHeight; b++) {
+                    if (
+                        gameState.gameOptions.revealBoardOnLoss ||
+                        gameState.board[b][a].isMine
+                    ) {
+                        performSpotReveal(a, b);
                     }
                 }
-            },
-        );
-        resolve(true);
-    });
+            }
+            return true;
+        }
+
+        visited.add(coordsStr);
+    }
+
+    return visited.size > 0;
 };
 
-const revealMultiple: (spotArr: MineBlock[]) => Promise<boolean> = function (spotArr: MineBlock[]) {
-    return new Promise((resolve) => {
-        const revealPromises = [];
-        for (let i = 0; i < spotArr.length; i++) {
-            revealPromises.push(revealSpot(spotArr[i].x, spotArr[i].y));
+const revealMultiple: (spotArr: MineBlock[]) => boolean = function (spotArr: MineBlock[]) {
+    let hasHitASpot = false;
+    for (let i = 0; i < spotArr.length; i++) {
+        if (revealSpot(spotArr[i].x, spotArr[i].y)) {
+            hasHitASpot = true;
         }
-        Promise.allSettled(revealPromises).then((results) => {
-            if (results.find((res) => res.status === 'fulfilled' && res.value)) {
-                resolve(true);
-                return;
-            }
-            resolve(false);
-        });
-    });
+    }
+    return hasHitASpot;
 };
 
 const getAdjacentSpots = function (x: number, y: number) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -659,6 +659,11 @@ export const setDebugEnabled = (enabled: boolean) => {
 
 /* To be used for tests */
 
+export const cleanupGame = () => {
+    // If timer isn't cleared on its own (ie. game doesn't end), then this will ensure the timer is cleared out
+    clearInterval(gameTimer);
+};
+
 export const getGameState: () => GameState = () => {
     return gameState;
 };

--- a/src/game.ts
+++ b/src/game.ts
@@ -413,15 +413,18 @@ const performSpotReveal = function (x: number, y: number, callback?: SpotRevealC
 const revealSpot: (x: number, y: number) => boolean = function (x: number, y: number) {
     const queue = [{x, y}];
     const visited = new Set();
+    let head = 0;
 
-    while (queue.length > 0) {
-        const coords = queue.shift()!;
-        const coordsStr = `${coords.x},${coords.y}`;
-        if (visited.has(coordsStr)) {
+    while (head < queue.length) {
+        const coords = queue[head++];
+        const coordsKey = coords.y * gameState.gameOptions.boardWidth + coords.x;
+        if (visited.has(coordsKey)) {
             continue;
         }
 
         const {isMine, amountOfAdjMines, adjacentSpots} = performSpotReveal(coords.x, coords.y);
+
+        visited.add(coordsKey);
 
         if (!isMine) {
             if (amountOfAdjMines <= 0) {
@@ -441,8 +444,6 @@ const revealSpot: (x: number, y: number) => boolean = function (x: number, y: nu
             }
             return true;
         }
-
-        visited.add(coordsStr);
     }
 
     return visited.size > 0;

--- a/src/game.ts
+++ b/src/game.ts
@@ -419,7 +419,8 @@ const revealSpot = function (x: number, y: number) {
 
         if (!isMine) {
             if (amountOfAdjMines <= 0) {
-                const toAdd = adjacentSpots?.filter((spot) => !spot.isFlagged) ?? [];
+                const toAdd =
+                    adjacentSpots?.filter((spot) => !spot.isFlagged && !spot.isRevealed) ?? [];
                 for (const spot of toAdd) {
                     const key = spot.y * gameState.gameOptions.boardWidth + spot.x;
                     if (!visited.has(key)) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -83,9 +83,9 @@ export type GameEvent =
 export type EventHandler = (event: GameEvent) => void;
 
 type SpotRevealResult = {
-    isMine: boolean,
-    amountOfAdjMines: number,
-    adjacentSpots: MineBlock[] | null,
+    isMine: boolean;
+    amountOfAdjMines: number;
+    adjacentSpots: MineBlock[] | null;
 };
 
 let gameState: GameState = {} as GameState;
@@ -408,33 +408,30 @@ const performSpotReveal: (x: number, y: number) => SpotRevealResult = function (
 };
 
 const revealSpot = function (x: number, y: number) {
-    const queue = [{x, y}];
+    const queue = [{ x, y }];
     const visited = new Set([y * gameState.gameOptions.boardWidth + x]);
     let head = 0;
 
     while (head < queue.length) {
         const coords = queue[head++];
 
-        const {isMine, amountOfAdjMines, adjacentSpots} = performSpotReveal(coords.x, coords.y);
+        const { isMine, amountOfAdjMines, adjacentSpots } = performSpotReveal(coords.x, coords.y);
 
         if (!isMine) {
             if (amountOfAdjMines <= 0) {
-                const toAdd = adjacentSpots?.filter(spot => !spot.isFlagged) ?? [];
+                const toAdd = adjacentSpots?.filter((spot) => !spot.isFlagged) ?? [];
                 for (const spot of toAdd) {
                     const key = spot.y * gameState.gameOptions.boardWidth + spot.x;
                     if (!visited.has(key)) {
                         visited.add(key);
-                        queue.push({x: spot.x, y: spot.y});
+                        queue.push({ x: spot.x, y: spot.y });
                     }
                 }
             }
         } else {
             for (let a = 0; a < gameState.gameOptions.boardWidth; a++) {
                 for (let b = 0; b < gameState.gameOptions.boardHeight; b++) {
-                    if (
-                        gameState.gameOptions.revealBoardOnLoss ||
-                        gameState.board[b][a].isMine
-                    ) {
+                    if (gameState.gameOptions.revealBoardOnLoss || gameState.board[b][a].isMine) {
                         performSpotReveal(a, b);
                     }
                 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -412,24 +412,24 @@ const performSpotReveal = function (x: number, y: number, callback?: SpotRevealC
 
 const revealSpot: (x: number, y: number) => boolean = function (x: number, y: number) {
     const queue = [{x, y}];
-    const visited = new Set();
+    const visited = new Set([y * gameState.gameOptions.boardWidth + x]);
     let head = 0;
 
     while (head < queue.length) {
         const coords = queue[head++];
-        const coordsKey = coords.y * gameState.gameOptions.boardWidth + coords.x;
-        if (visited.has(coordsKey)) {
-            continue;
-        }
 
         const {isMine, amountOfAdjMines, adjacentSpots} = performSpotReveal(coords.x, coords.y);
-
-        visited.add(coordsKey);
 
         if (!isMine) {
             if (amountOfAdjMines <= 0) {
                 const toAdd = adjacentSpots?.filter(spot => !spot.isFlagged) ?? [];
-                queue.push(...toAdd.map(spot => ({x: spot.x, y: spot.y})));
+                for (const spot of toAdd) {
+                    const key = spot.y * gameState.gameOptions.boardWidth + spot.x;
+                    if (!visited.has(key)) {
+                        visited.add(key);
+                        queue.push({x: spot.x, y: spot.y});
+                    }
+                }
             }
         } else {
             for (let a = 0; a < gameState.gameOptions.boardWidth; a++) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -138,7 +138,7 @@ const initPersistentState = () => {
     }
 };
 
-export const initGame = async (
+export const initGame = (
     gameOptions: GameOptions,
     _eventHandler: EventHandler,
     _gameStorage: IGameStorage,

--- a/src/game.ts
+++ b/src/game.ts
@@ -82,11 +82,11 @@ export type GameEvent =
 
 export type EventHandler = (event: GameEvent) => void;
 
-type SpotRevealCallback = (
+type SpotRevealResult = {
     isMine: boolean,
     amountOfAdjMines: number,
     adjacentSpots: MineBlock[] | null,
-) => void;
+};
 
 let gameState: GameState = {} as GameState;
 let persistentState: GamePersistentState = {} as GamePersistentState;
@@ -387,7 +387,7 @@ export const selectAdjacentSpots = function (x: number, y: number) {
     return { hitInfo: 'land', win: won };
 };
 
-const performSpotReveal = function (x: number, y: number, callback?: SpotRevealCallback) {
+const performSpotReveal: (x: number, y: number) => SpotRevealResult = function (x, y) {
     gameState.board[y][x].isRevealed = true;
     // Clear any question mark when revealing
     gameState.board[y][x].isQuestionMark = false;
@@ -400,9 +400,6 @@ const performSpotReveal = function (x: number, y: number, callback?: SpotRevealC
         amountOfAdjMines = calculateAdjacentMines(adjacentSpots);
         gameState.board[y][x].adjMinesCount = amountOfAdjMines;
     }
-    if (callback) {
-        callback(isMine, amountOfAdjMines, adjacentSpots);
-    }
     return {
         isMine,
         amountOfAdjMines,
@@ -410,7 +407,7 @@ const performSpotReveal = function (x: number, y: number, callback?: SpotRevealC
     };
 };
 
-const revealSpot: (x: number, y: number) => boolean = function (x: number, y: number) {
+const revealSpot = function (x: number, y: number) {
     const queue = [{x, y}];
     const visited = new Set([y * gameState.gameOptions.boardWidth + x]);
     let head = 0;
@@ -442,19 +439,18 @@ const revealSpot: (x: number, y: number) => boolean = function (x: number, y: nu
                     }
                 }
             }
-            return true;
         }
     }
-
-    return visited.size > 0;
 };
 
 const revealMultiple: (spotArr: MineBlock[]) => boolean = function (spotArr: MineBlock[]) {
     let hasHitASpot = false;
     for (let i = 0; i < spotArr.length; i++) {
-        if (revealSpot(spotArr[i].x, spotArr[i].y)) {
-            hasHitASpot = true;
+        if (gameState.board[spotArr[i].y][spotArr[i].x].isRevealed) {
+            continue;
         }
+        revealSpot(spotArr[i].x, spotArr[i].y);
+        hasHitASpot = true;
     }
     return hasHitASpot;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -495,7 +495,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             loaderWrapper.style.display = 'none';
         }, 1000);
 
-        await initGame(frontendState.gameOptions, eventHandler, gameStorage);
+        initGame(frontendState.gameOptions, eventHandler, gameStorage);
     } catch (e) {
         // if (typeof Sentry !== 'undefined') Sentry.captureException(e);
         const elem = createDialogContentFromTemplate('#error-dialog-content');

--- a/test/audio.test.ts
+++ b/test/audio.test.ts
@@ -247,7 +247,9 @@ describe('AudioManager', () => {
             expect(mockDocument.addEventListener).toHaveBeenCalledWith(
                 'touchstart',
                 expect.any(Function),
-                { passive: true },
+                {
+                    passive: true,
+                },
             );
         });
 

--- a/test/audio.test.ts
+++ b/test/audio.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect } from '@jest/globals';
+import { jest, expect, describe, beforeEach, it } from '@jest/globals';
 import { AudioManager, SoundEffect } from '../src/manager/audio';
 import { AssetManager } from '../src/manager/asset';
 import { Howler } from 'howler';

--- a/test/board-movement.test.ts
+++ b/test/board-movement.test.ts
@@ -7,11 +7,8 @@ import { IGameStorage } from '../src/storage';
 describe('selecting tiles', function () {
     let eventHandlerStub: Mock;
 
-    async function setupGame(
-        gameStorage: IGameStorage,
-        gameOptions: GameOptions,
-    ): Promise<GameState> {
-        await initGame(gameOptions, eventHandlerStub, gameStorage);
+    function setupGame(gameStorage: IGameStorage, gameOptions: GameOptions): GameState {
+        initGame(gameOptions, eventHandlerStub, gameStorage);
         return getGameState();
     }
 
@@ -19,8 +16,8 @@ describe('selecting tiles', function () {
         eventHandlerStub = jest.fn();
     });
 
-    it('will select a spot on the board by marking it as revealed', async function () {
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+    it('will select a spot on the board by marking it as revealed', function () {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 10,
             boardHeight: 10,
             numberOfMines: 10,
@@ -33,8 +30,8 @@ describe('selecting tiles', function () {
         expect(gameState.board[2][2].isRevealed).toBe(true);
     });
 
-    it('will prevent the user from selecting the same spot on the board twice', async function () {
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+    it('will prevent the user from selecting the same spot on the board twice', function () {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 10,
             boardHeight: 10,
             numberOfMines: 10,
@@ -55,11 +52,8 @@ describe('selecting tiles', function () {
 describe('flagging tiles', function () {
     let eventHandlerStub: Mock;
 
-    async function setupGame(
-        gameStorage: IGameStorage,
-        gameOptions: GameOptions,
-    ): Promise<GameState> {
-        await initGame(gameOptions, eventHandlerStub, gameStorage);
+    function setupGame(gameStorage: IGameStorage, gameOptions: GameOptions): GameState {
+        initGame(gameOptions, eventHandlerStub, gameStorage);
         return getGameState();
     }
 
@@ -67,8 +61,8 @@ describe('flagging tiles', function () {
         eventHandlerStub = jest.fn();
     });
 
-    it('will flag a spot on the board by marking it as flagged', async function () {
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+    it('will flag a spot on the board by marking it as flagged', function () {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 10,
             boardHeight: 10,
             numberOfMines: 10,
@@ -89,11 +83,8 @@ describe('flagging tiles', function () {
 describe('unflagging tiles', function () {
     let eventHandlerStub: Mock;
 
-    async function setupGame(
-        gameStorage: IGameStorage,
-        gameOptions: GameOptions,
-    ): Promise<GameState> {
-        await initGame(gameOptions, eventHandlerStub, gameStorage);
+    function setupGame(gameStorage: IGameStorage, gameOptions: GameOptions): GameState {
+        initGame(gameOptions, eventHandlerStub, gameStorage);
         return getGameState();
     }
 
@@ -101,8 +92,8 @@ describe('unflagging tiles', function () {
         eventHandlerStub = jest.fn();
     });
 
-    it('will unflag a spot on the board by calling the flag function twice', async function () {
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+    it('will unflag a spot on the board by calling the flag function twice', function () {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 10,
             boardHeight: 10,
             numberOfMines: 10,

--- a/test/board-movement.test.ts
+++ b/test/board-movement.test.ts
@@ -1,5 +1,13 @@
 import { jest, expect, describe, beforeEach, it } from '@jest/globals';
-import { initGame, selectSpot, flagSpot, getGameState, GameOptions, GameState } from '../src/game';
+import {
+    initGame,
+    selectSpot,
+    flagSpot,
+    getGameState,
+    GameOptions,
+    GameState,
+    cleanupGame,
+} from '../src/game';
 import { Mock } from 'jest-mock';
 import { NonexistentMockGameStorage } from './util';
 import { IGameStorage } from '../src/storage';
@@ -14,6 +22,10 @@ describe('selecting tiles', function () {
 
     beforeEach(() => {
         eventHandlerStub = jest.fn();
+    });
+
+    afterEach(() => {
+        cleanupGame();
     });
 
     it('will select a spot on the board by marking it as revealed', function () {

--- a/test/board-movement.test.ts
+++ b/test/board-movement.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect, describe, beforeEach, it } from '@jest/globals';
+import { jest, expect, describe, beforeEach, afterEach, it } from '@jest/globals';
 import {
     initGame,
     selectSpot,

--- a/test/board-movement.test.ts
+++ b/test/board-movement.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect } from '@jest/globals';
+import { jest, expect, describe, beforeEach, it } from '@jest/globals';
 import { initGame, selectSpot, flagSpot, getGameState, GameOptions, GameState } from '../src/game';
 import { Mock } from 'jest-mock';
 import { NonexistentMockGameStorage } from './util';

--- a/test/board-setup.test.ts
+++ b/test/board-setup.test.ts
@@ -15,11 +15,8 @@ import { IGameStorage } from '../src/storage';
 describe('board setup', function () {
     let eventHandlerStub: Mock;
 
-    async function setupGame(
-        gameStorage: IGameStorage,
-        gameOptions: GameOptions,
-    ): Promise<GameState> {
-        await initGame(gameOptions, eventHandlerStub, gameStorage);
+    function setupGame(gameStorage: IGameStorage, gameOptions: GameOptions): GameState {
+        initGame(gameOptions, eventHandlerStub, gameStorage);
         return getGameState();
     }
 
@@ -27,8 +24,8 @@ describe('board setup', function () {
         eventHandlerStub = jest.fn();
     });
 
-    it('should initialize a game 10 wide, 10 high, with 10 mines', async function () {
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+    it('should initialize a game 10 wide, 10 high, with 10 mines', function () {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 10,
             boardHeight: 10,
             numberOfMines: 10,
@@ -52,11 +49,8 @@ describe('board setup', function () {
 describe('board overfill', function () {
     let eventHandlerStub: Mock;
 
-    async function setupGame(
-        gameStorage: IGameStorage,
-        gameOptions: GameOptions,
-    ): Promise<GameState> {
-        await initGame(gameOptions, eventHandlerStub, gameStorage);
+    function setupGame(gameStorage: IGameStorage, gameOptions: GameOptions): GameState {
+        initGame(gameOptions, eventHandlerStub, gameStorage);
         return getGameState();
     }
 
@@ -65,7 +59,7 @@ describe('board overfill', function () {
     });
 
     it('should throw an error if the board has more mines than board tiles', function () {
-        expect(
+        expect(() =>
             setupGame(new NonexistentMockGameStorage(), {
                 boardWidth: 10,
                 boardHeight: 10,
@@ -73,7 +67,7 @@ describe('board overfill', function () {
                 revealBoardOnLoss: true,
                 difficultyKey: 'easy',
             }),
-        ).rejects.toThrow(
+        ).toThrow(
             new BoardOverfillException(
                 'Amount of mines to generate exceeds amount of board pieces.',
             ),
@@ -81,7 +75,7 @@ describe('board overfill', function () {
     });
 
     it('should throw an error if the board has as many mines are there are board tiles', function () {
-        expect(
+        expect(() =>
             setupGame(new NonexistentMockGameStorage(), {
                 boardWidth: 10,
                 boardHeight: 10,
@@ -89,7 +83,7 @@ describe('board overfill', function () {
                 revealBoardOnLoss: true,
                 difficultyKey: 'easy',
             }),
-        ).rejects.toThrow(
+        ).toThrow(
             new BoardOverfillException(
                 'Amount of mines to generate is equal to the amount of board pieces.',
             ),
@@ -100,11 +94,8 @@ describe('board overfill', function () {
 describe('first click', () => {
     let eventHandlerStub: Mock;
 
-    async function setupGame(
-        gameStorage: IGameStorage,
-        gameOptions: GameOptions,
-    ): Promise<GameState> {
-        await initGame(gameOptions, eventHandlerStub, gameStorage);
+    function setupGame(gameStorage: IGameStorage, gameOptions: GameOptions): GameState {
+        initGame(gameOptions, eventHandlerStub, gameStorage);
         return getGameState();
     }
 
@@ -113,9 +104,9 @@ describe('first click', () => {
         setDebugEnabled(false);
     });
 
-    it('should never be a mine', async () => {
+    it('should never be a mine', () => {
         for (let i = 0; i < 10000; i++) {
-            const gameState = await setupGame(new NonexistentMockGameStorage(), {
+            const gameState = setupGame(new NonexistentMockGameStorage(), {
                 boardWidth: 10,
                 boardHeight: 10,
                 numberOfMines: 10,
@@ -128,8 +119,8 @@ describe('first click', () => {
         }
     });
 
-    it('should not generate an automatic win if mine is clicked first', async () => {
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+    it('should not generate an automatic win if mine is clicked first', () => {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 10,
             boardHeight: 10,
             numberOfMines: 10,

--- a/test/board-setup.test.ts
+++ b/test/board-setup.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect, describe, beforeEach, it } from '@jest/globals';
+import { jest, expect, describe, beforeEach, afterEach, it } from '@jest/globals';
 import {
     GameState,
     initGame,
@@ -6,6 +6,7 @@ import {
     getGameState,
     selectSpot,
     setDebugEnabled,
+    cleanupGame,
 } from '../src/game';
 import { BoardOverfillException } from '../src/errors';
 import { NonexistentMockGameStorage } from './util';
@@ -102,6 +103,10 @@ describe('first click', () => {
     beforeEach(() => {
         eventHandlerStub = jest.fn();
         setDebugEnabled(false);
+    });
+
+    afterEach(() => {
+        cleanupGame();
     });
 
     it('should never be a mine', () => {

--- a/test/board-setup.test.ts
+++ b/test/board-setup.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect } from '@jest/globals';
+import { jest, expect, describe, beforeEach, it } from '@jest/globals';
 import {
     GameState,
     initGame,

--- a/test/large-board-scalability.test.ts
+++ b/test/large-board-scalability.test.ts
@@ -4,7 +4,7 @@ import { NonexistentMockGameStorage } from './util';
 import { Mock } from 'jest-mock';
 
 /**
- * Scalability regression test for large board flood fill.
+ * Scalability regression tests for large board flood fill.
  *
  * The current implementation uses a mutually-recursive flood fill
  * (revealSpot → revealMultiple → revealSpot …) whose executors run
@@ -13,14 +13,15 @@ import { Mock } from 'jest-mock';
  * exceeded". The RangeError is silently swallowed by the Promise machinery,
  * so the flood fill terminates early and leaves most tiles unrevealed.
  *
- * On a 1 000×1 000 board with only 10 mines, a flood fill from (0, 0) should
- * reveal all 999 990 non-mine cells and immediately win the game. If the
+ * Each test places the single mine at the center of the board so that
+ * clicking (0, 0) is guaranteed to trigger a full flood fill. If the
  * recursive implementation stack-overflows mid-fill, far fewer cells will be
- * revealed and the game will NOT be won — which is how this test catches the
+ * revealed and the game will NOT be won — which is how these tests catch the
  * bug.
  *
- * This test is intentionally RED. It documents the known failure so that a
- * future iterative implementation can turn it GREEN.
+ * These tests are intentionally RED. They document the known failure so that
+ * a future iterative implementation can turn them GREEN.
+ * See: https://github.com/Coteh/MinesweeperClone/issues/3
  */
 describe('large board scalability', () => {
     let eventHandlerStub: Mock;
@@ -79,4 +80,49 @@ loop:
         }
         expect(revealedCount).toBe(expectedRevealed);
     }, 30000 /* 30 s ceiling — the crash happens well before this */);
+
+    it('should complete a flood fill on a 100x100 board without stack overflow', async () => {
+        // 10 000 cells, 1 mine → 9 999 safe cells.
+        const gameOptions: GameOptions = {
+            boardWidth: 100,
+            boardHeight: 100,
+            numberOfMines: 1,
+            revealBoardOnLoss: false,
+            difficultyKey: 'custom',
+        };
+
+        await initGame(gameOptions, eventHandlerStub, new NonexistentMockGameStorage());
+
+        // Move the mine to the center so that revealing a spot will always flood fill
+        let state = getGameState();
+loop:
+        for (let i = 0; i < gameOptions.boardHeight; i++) {
+            for (let j = 0; j < gameOptions.boardWidth; j++) {
+                if (state.board[i][j].isMine) {
+                    state.board[i][j].isMine = false;
+                    break loop;
+                }
+            }
+        }
+        state.board[Math.floor(gameOptions.boardHeight / 2)][Math.floor(gameOptions.boardWidth / 2)].isMine = true;
+
+        // Reveal top left corner
+        const result = selectSpot(0, 0);
+
+        expect(result.win).toBe(true);
+
+        // Double-check via game state: every non-mine cell must be revealed.
+        state = getGameState();
+        const totalCells = gameOptions.boardWidth * gameOptions.boardHeight;
+        const expectedRevealed = totalCells - gameOptions.numberOfMines;
+        let revealedCount = 0;
+        for (let y = 0; y < gameOptions.boardHeight; y++) {
+            for (let x = 0; x < gameOptions.boardWidth; x++) {
+                if (state.board[y][x].isRevealed && !state.board[y][x].isMine) {
+                    revealedCount++;
+                }
+            }
+        }
+        expect(revealedCount).toBe(expectedRevealed);
+    }, 10000 /* 10 s ceiling */);
 });

--- a/test/large-board-scalability.test.ts
+++ b/test/large-board-scalability.test.ts
@@ -30,6 +30,51 @@ describe('large board scalability', () => {
         eventHandlerStub = jest.fn();
     });
 
+    it('should complete a flood fill on a 100x100 board without stack overflow', async () => {
+        // 10 000 cells, 1 mine → 9 999 safe cells.
+        const gameOptions: GameOptions = {
+            boardWidth: 100,
+            boardHeight: 100,
+            numberOfMines: 1,
+            revealBoardOnLoss: false,
+            difficultyKey: 'custom',
+        };
+
+        await initGame(gameOptions, eventHandlerStub, new NonexistentMockGameStorage());
+
+        // Move the mine to the center so that revealing a spot will always flood fill
+        let state = getGameState();
+loop:
+        for (let i = 0; i < gameOptions.boardHeight; i++) {
+            for (let j = 0; j < gameOptions.boardWidth; j++) {
+                if (state.board[i][j].isMine) {
+                    state.board[i][j].isMine = false;
+                    break loop;
+                }
+            }
+        }
+        state.board[Math.floor(gameOptions.boardHeight / 2)][Math.floor(gameOptions.boardWidth / 2)].isMine = true;
+
+        // Reveal top left corner
+        const result = selectSpot(0, 0);
+
+        expect(result.win).toBe(true);
+
+        // Double-check via game state: every non-mine cell must be revealed.
+        state = getGameState();
+        const totalCells = gameOptions.boardWidth * gameOptions.boardHeight;
+        const expectedRevealed = totalCells - gameOptions.numberOfMines;
+        let revealedCount = 0;
+        for (let y = 0; y < gameOptions.boardHeight; y++) {
+            for (let x = 0; x < gameOptions.boardWidth; x++) {
+                if (state.board[y][x].isRevealed && !state.board[y][x].isMine) {
+                    revealedCount++;
+                }
+            }
+        }
+        expect(revealedCount).toBe(expectedRevealed);
+    }, 10000 /* 10 s ceiling */);
+
     it('should complete a flood fill on a 1000x1000 board without stack overflow', async () => {
         // 1 000 000 cells, 10 mines → 999 990 safe cells.
         // With so few mines the entire safe region is almost certainly a single
@@ -80,49 +125,4 @@ loop:
         }
         expect(revealedCount).toBe(expectedRevealed);
     }, 30000 /* 30 s ceiling — the crash happens well before this */);
-
-    it('should complete a flood fill on a 100x100 board without stack overflow', async () => {
-        // 10 000 cells, 1 mine → 9 999 safe cells.
-        const gameOptions: GameOptions = {
-            boardWidth: 100,
-            boardHeight: 100,
-            numberOfMines: 1,
-            revealBoardOnLoss: false,
-            difficultyKey: 'custom',
-        };
-
-        await initGame(gameOptions, eventHandlerStub, new NonexistentMockGameStorage());
-
-        // Move the mine to the center so that revealing a spot will always flood fill
-        let state = getGameState();
-loop:
-        for (let i = 0; i < gameOptions.boardHeight; i++) {
-            for (let j = 0; j < gameOptions.boardWidth; j++) {
-                if (state.board[i][j].isMine) {
-                    state.board[i][j].isMine = false;
-                    break loop;
-                }
-            }
-        }
-        state.board[Math.floor(gameOptions.boardHeight / 2)][Math.floor(gameOptions.boardWidth / 2)].isMine = true;
-
-        // Reveal top left corner
-        const result = selectSpot(0, 0);
-
-        expect(result.win).toBe(true);
-
-        // Double-check via game state: every non-mine cell must be revealed.
-        state = getGameState();
-        const totalCells = gameOptions.boardWidth * gameOptions.boardHeight;
-        const expectedRevealed = totalCells - gameOptions.numberOfMines;
-        let revealedCount = 0;
-        for (let y = 0; y < gameOptions.boardHeight; y++) {
-            for (let x = 0; x < gameOptions.boardWidth; x++) {
-                if (state.board[y][x].isRevealed && !state.board[y][x].isMine) {
-                    revealedCount++;
-                }
-            }
-        }
-        expect(revealedCount).toBe(expectedRevealed);
-    }, 10000 /* 10 s ceiling */);
 });

--- a/test/large-board-scalability.test.ts
+++ b/test/large-board-scalability.test.ts
@@ -21,7 +21,7 @@ describe('large board scalability', () => {
         eventHandlerStub = jest.fn();
     });
 
-    it('should complete a flood fill on a 100x100 board without stack overflow', async () => {
+    it('should complete a flood fill on a 100x100 board without stack overflow', () => {
         // 10 000 cells, 1 mine → 9 999 safe cells.
         const gameOptions: GameOptions = {
             boardWidth: 100,
@@ -31,7 +31,7 @@ describe('large board scalability', () => {
             difficultyKey: 'custom',
         };
 
-        await initGame(gameOptions, eventHandlerStub, new NonexistentMockGameStorage());
+        initGame(gameOptions, eventHandlerStub, new NonexistentMockGameStorage());
 
         // Move the mine to the center so that revealing a spot will always flood fill
         let state = getGameState();
@@ -67,7 +67,7 @@ describe('large board scalability', () => {
         expect(revealedCount).toBe(expectedRevealed);
     }, 10000 /* 10 s ceiling */);
 
-    it('should complete a flood fill on a 1000x1000 board without stack overflow', async () => {
+    it('should complete a flood fill on a 1000x1000 board without stack overflow', () => {
         // 1 000 000 cells, 1 mine → 999 999 safe cells.
         const gameOptions: GameOptions = {
             boardWidth: 1000,
@@ -77,7 +77,7 @@ describe('large board scalability', () => {
             difficultyKey: 'custom',
         };
 
-        await initGame(gameOptions, eventHandlerStub, new NonexistentMockGameStorage());
+        initGame(gameOptions, eventHandlerStub, new NonexistentMockGameStorage());
 
         // Move the mine to the center so that revealing a spot will always flood fill
         let state = getGameState();

--- a/test/large-board-scalability.test.ts
+++ b/test/large-board-scalability.test.ts
@@ -1,5 +1,5 @@
-import { jest, expect, describe, beforeEach, it } from '@jest/globals';
-import { initGame, GameOptions, getGameState, selectSpot } from '../src/game';
+import { jest, expect, describe, beforeEach, afterEach, it } from '@jest/globals';
+import { initGame, GameOptions, getGameState, selectSpot, cleanupGame } from '../src/game';
 import { NonexistentMockGameStorage } from './util';
 import { Mock } from 'jest-mock';
 
@@ -19,6 +19,10 @@ describe('large board scalability', () => {
 
     beforeEach(() => {
         eventHandlerStub = jest.fn();
+    });
+
+    afterEach(() => {
+        cleanupGame();
     });
 
     it('should complete a flood fill on a 100x100 board without stack overflow', () => {

--- a/test/large-board-scalability.test.ts
+++ b/test/large-board-scalability.test.ts
@@ -35,8 +35,7 @@ describe('large board scalability', () => {
 
         // Move the mine to the center so that revealing a spot will always flood fill
         let state = getGameState();
-loop:
-        for (let i = 0; i < gameOptions.boardHeight; i++) {
+        loop: for (let i = 0; i < gameOptions.boardHeight; i++) {
             for (let j = 0; j < gameOptions.boardWidth; j++) {
                 if (state.board[i][j].isMine) {
                     state.board[i][j].isMine = false;
@@ -44,7 +43,9 @@ loop:
                 }
             }
         }
-        state.board[Math.floor(gameOptions.boardHeight / 2)][Math.floor(gameOptions.boardWidth / 2)].isMine = true;
+        const centerX = Math.floor(gameOptions.boardWidth / 2);
+        const centerY = Math.floor(gameOptions.boardHeight / 2);
+        state.board[centerY][centerX].isMine = true;
 
         // Reveal top left corner
         const result = selectSpot(0, 0);
@@ -80,8 +81,7 @@ loop:
 
         // Move the mine to the center so that revealing a spot will always flood fill
         let state = getGameState();
-loop:
-        for (let i = 0; i < gameOptions.boardHeight; i++) {
+        loop: for (let i = 0; i < gameOptions.boardHeight; i++) {
             for (let j = 0; j < gameOptions.boardWidth; j++) {
                 if (state.board[i][j].isMine) {
                     state.board[i][j].isMine = false;
@@ -89,8 +89,10 @@ loop:
                 }
             }
         }
-        state.board[Math.floor(gameOptions.boardHeight / 2)][Math.floor(gameOptions.boardWidth / 2)].isMine = true;
-        
+        const centerX = Math.floor(gameOptions.boardWidth / 2);
+        const centerY = Math.floor(gameOptions.boardHeight / 2);
+        state.board[centerY][centerX].isMine = true;
+
         // Reveal top left corner
         const result = selectSpot(0, 0);
 

--- a/test/large-board-scalability.test.ts
+++ b/test/large-board-scalability.test.ts
@@ -1,0 +1,67 @@
+import { jest, expect } from '@jest/globals';
+import { initGame, GameOptions, getGameState, selectSpot } from '../src/game';
+import { NonexistentMockGameStorage } from './util';
+import { Mock } from 'jest-mock';
+
+/**
+ * Scalability regression test for large board flood fill.
+ *
+ * The current implementation uses a mutually-recursive flood fill
+ * (revealSpot → revealMultiple → revealSpot …) whose executors run
+ * synchronously inside Promise constructors. On a large board this exhausts
+ * the JavaScript call stack with "RangeError: Maximum call stack size
+ * exceeded". The RangeError is silently swallowed by the Promise machinery,
+ * so the flood fill terminates early and leaves most tiles unrevealed.
+ *
+ * On a 1 000×1 000 board with only 10 mines, a flood fill from (0, 0) should
+ * reveal all 999 990 non-mine cells and immediately win the game. If the
+ * recursive implementation stack-overflows mid-fill, far fewer cells will be
+ * revealed and the game will NOT be won — which is how this test catches the
+ * bug.
+ *
+ * This test is intentionally RED. It documents the known failure so that a
+ * future iterative implementation can turn it GREEN.
+ */
+describe('large board scalability', () => {
+    let eventHandlerStub: Mock;
+
+    beforeEach(() => {
+        eventHandlerStub = jest.fn();
+    });
+
+    it('should complete a flood fill on a 1000x1000 board without stack overflow', async () => {
+        // 1 000 000 cells, 10 mines → 999 990 safe cells.
+        // With so few mines the entire safe region is almost certainly a single
+        // connected component, so one click should reveal every safe cell and
+        // immediately win the game.
+        const gameOptions: GameOptions = {
+            boardWidth: 1000,
+            boardHeight: 1000,
+            numberOfMines: 10,
+            revealBoardOnLoss: false,
+            difficultyKey: 'custom',
+        };
+
+        await initGame(gameOptions, eventHandlerStub, new NonexistentMockGameStorage());
+
+        // The recursive flood fill silently overflows the call stack inside a
+        // Promise constructor, leaving most tiles unrevealed. The game is
+        // therefore never won. This assertion exposes that failure.
+        const result = selectSpot(0, 0);
+        expect(result.win).toBe(true);
+
+        // Double-check via game state: every non-mine cell must be revealed.
+        const state = getGameState();
+        const totalCells = gameOptions.boardWidth * gameOptions.boardHeight;
+        const expectedRevealed = totalCells - gameOptions.numberOfMines;
+        let revealedCount = 0;
+        for (let y = 0; y < gameOptions.boardHeight; y++) {
+            for (let x = 0; x < gameOptions.boardWidth; x++) {
+                if (state.board[y][x].isRevealed && !state.board[y][x].isMine) {
+                    revealedCount++;
+                }
+            }
+        }
+        expect(revealedCount).toBe(expectedRevealed);
+    }, 30000 /* 30 s ceiling — the crash happens well before this */);
+});

--- a/test/large-board-scalability.test.ts
+++ b/test/large-board-scalability.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect } from '@jest/globals';
+import { jest, expect, describe, beforeEach, it } from '@jest/globals';
 import { initGame, GameOptions, getGameState, selectSpot } from '../src/game';
 import { NonexistentMockGameStorage } from './util';
 import { Mock } from 'jest-mock';

--- a/test/large-board-scalability.test.ts
+++ b/test/large-board-scalability.test.ts
@@ -4,23 +4,14 @@ import { NonexistentMockGameStorage } from './util';
 import { Mock } from 'jest-mock';
 
 /**
- * Scalability regression tests for large board flood fill.
+ * Scalability regression tests for the flood fill reveal logic.
  *
- * The current implementation uses a mutually-recursive flood fill
- * (revealSpot → revealMultiple → revealSpot …) whose executors run
- * synchronously inside Promise constructors. On a large board this exhausts
- * the JavaScript call stack with "RangeError: Maximum call stack size
- * exceeded". The RangeError is silently swallowed by the Promise machinery,
- * so the flood fill terminates early and leaves most tiles unrevealed.
+ * The original recursive implementation overflows the JS call stack on boards
+ * of 100×100 or larger, aborting the fill mid-way and leaving most tiles
+ * unrevealed. Each test places the single mine at the center so that clicking
+ * (0, 0) is guaranteed to trigger a full flood fill. The assertion — that the
+ * game is won (all safe cells revealed) — serves as the pass/fail signal.
  *
- * Each test places the single mine at the center of the board so that
- * clicking (0, 0) is guaranteed to trigger a full flood fill. If the
- * recursive implementation stack-overflows mid-fill, far fewer cells will be
- * revealed and the game will NOT be won — which is how these tests catch the
- * bug.
- *
- * These tests are intentionally RED. They document the known failure so that
- * a future iterative implementation can turn them GREEN.
  * See: https://github.com/Coteh/MinesweeperClone/issues/3
  */
 describe('large board scalability', () => {
@@ -76,10 +67,7 @@ loop:
     }, 10000 /* 10 s ceiling */);
 
     it('should complete a flood fill on a 1000x1000 board without stack overflow', async () => {
-        // 1 000 000 cells, 10 mines → 999 990 safe cells.
-        // With so few mines the entire safe region is almost certainly a single
-        // connected component, so one click should reveal every safe cell and
-        // immediately win the game.
+        // 1 000 000 cells, 1 mine → 999 999 safe cells.
         const gameOptions: GameOptions = {
             boardWidth: 1000,
             boardHeight: 1000,
@@ -106,9 +94,6 @@ loop:
         // Reveal top left corner
         const result = selectSpot(0, 0);
 
-        // The recursive flood fill silently overflows the call stack inside a
-        // Promise constructor, leaving most tiles unrevealed. The game is
-        // therefore never won. This assertion exposes that failure.
         expect(result.win).toBe(true);
 
         // Double-check via game state: every non-mine cell must be revealed.
@@ -124,5 +109,5 @@ loop:
             }
         }
         expect(revealedCount).toBe(expectedRevealed);
-    }, 30000 /* 30 s ceiling — the crash happens well before this */);
+    }, 120000 /* 2 min ceiling */);
 });

--- a/test/large-board-scalability.test.ts
+++ b/test/large-board-scalability.test.ts
@@ -37,21 +37,36 @@ describe('large board scalability', () => {
         const gameOptions: GameOptions = {
             boardWidth: 1000,
             boardHeight: 1000,
-            numberOfMines: 10,
+            numberOfMines: 1,
             revealBoardOnLoss: false,
             difficultyKey: 'custom',
         };
 
         await initGame(gameOptions, eventHandlerStub, new NonexistentMockGameStorage());
 
+        // Move the mine to the center so that revealing a spot will always flood fill
+        let state = getGameState();
+loop:
+        for (let i = 0; i < gameOptions.boardHeight; i++) {
+            for (let j = 0; j < gameOptions.boardWidth; j++) {
+                if (state.board[i][j].isMine) {
+                    state.board[i][j].isMine = false;
+                    break loop;
+                }
+            }
+        }
+        state.board[Math.floor(gameOptions.boardHeight / 2)][Math.floor(gameOptions.boardWidth / 2)].isMine = true;
+        
+        // Reveal top left corner
+        const result = selectSpot(0, 0);
+
         // The recursive flood fill silently overflows the call stack inside a
         // Promise constructor, leaving most tiles unrevealed. The game is
         // therefore never won. This assertion exposes that failure.
-        const result = selectSpot(0, 0);
         expect(result.win).toBe(true);
 
         // Double-check via game state: every non-mine cell must be revealed.
-        const state = getGameState();
+        state = getGameState();
         const totalCells = gameOptions.boardWidth * gameOptions.boardHeight;
         const expectedRevealed = totalCells - gameOptions.numberOfMines;
         let revealedCount = 0;

--- a/test/mine-count.test.ts
+++ b/test/mine-count.test.ts
@@ -7,11 +7,8 @@ import { IGameStorage } from '../src/storage';
 describe('mine count with flags on loss', function () {
     let eventHandlerStub: Mock;
 
-    async function setupGame(
-        gameStorage: IGameStorage,
-        gameOptions: GameOptions,
-    ): Promise<GameState> {
-        await initGame(gameOptions, eventHandlerStub, gameStorage);
+    function setupGame(gameStorage: IGameStorage, gameOptions: GameOptions): GameState {
+        initGame(gameOptions, eventHandlerStub, gameStorage);
         return getGameState();
     }
 
@@ -26,13 +23,13 @@ describe('mine count with flags on loss', function () {
         eventHandlerStub = jest.fn();
     });
 
-    it('should maintain mine count when flagged mines are revealed on loss', async function () {
+    it('should maintain mine count when flagged mines are revealed on loss', function () {
         // Create a simple 3x3 board with 2 mines
         // Layout:
         // M . .
         // . M .
         // . . .
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 3,
             boardHeight: 3,
             numberOfMines: 2,
@@ -95,9 +92,9 @@ describe('mine count with flags on loss', function () {
         expect(unflaggedMineCount).toBe(1);
     });
 
-    it('should maintain mine count at zero when all mines are flagged before loss', async function () {
+    it('should maintain mine count at zero when all mines are flagged before loss', function () {
         // Create a simple 3x3 board with 2 mines
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 3,
             boardHeight: 3,
             numberOfMines: 2,
@@ -155,9 +152,9 @@ describe('mine count with flags on loss', function () {
         expect(unflaggedMineCount).toBe(1);
     });
 
-    it('should show correct mine count when multiple mines flagged correctly', async function () {
+    it('should show correct mine count when multiple mines flagged correctly', function () {
         // Create a larger board to test with more mines
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 5,
             boardHeight: 5,
             numberOfMines: 5,

--- a/test/mine-count.test.ts
+++ b/test/mine-count.test.ts
@@ -1,5 +1,13 @@
-import { jest, expect, describe, beforeEach, it } from '@jest/globals';
-import { initGame, selectSpot, flagSpot, getGameState, GameOptions, GameState } from '../src/game';
+import { jest, expect, describe, beforeEach, afterEach, it } from '@jest/globals';
+import {
+    initGame,
+    selectSpot,
+    flagSpot,
+    getGameState,
+    GameOptions,
+    GameState,
+    cleanupGame,
+} from '../src/game';
 import { Mock } from 'jest-mock';
 import { NonexistentMockGameStorage } from './util';
 import { IGameStorage } from '../src/storage';
@@ -21,6 +29,10 @@ describe('mine count with flags on loss', function () {
 
     beforeEach(() => {
         eventHandlerStub = jest.fn();
+    });
+
+    afterEach(() => {
+        cleanupGame();
     });
 
     it('should maintain mine count when flagged mines are revealed on loss', function () {

--- a/test/mine-count.test.ts
+++ b/test/mine-count.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect } from '@jest/globals';
+import { jest, expect, describe, beforeEach, it } from '@jest/globals';
 import { initGame, selectSpot, flagSpot, getGameState, GameOptions, GameState } from '../src/game';
 import { Mock } from 'jest-mock';
 import { NonexistentMockGameStorage } from './util';

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect, describe, it, beforeEach } from '@jest/globals';
+import { jest, expect, describe, it, beforeEach, afterEach } from '@jest/globals';
 
 // Mock the background module to avoid pulling in pixi.js in node environment
 jest.mock('../src/manager/background', () => ({

--- a/test/win-auto-flag.test.ts
+++ b/test/win-auto-flag.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect, describe, beforeEach, it } from '@jest/globals';
+import { jest, expect, describe, beforeEach, afterEach, it } from '@jest/globals';
 import {
     initGame,
     selectSpot,
@@ -7,6 +7,7 @@ import {
     getGameState,
     GameOptions,
     GameState,
+    cleanupGame,
 } from '../src/game';
 import { Mock } from 'jest-mock';
 import { NonexistentMockGameStorage, MockGameStorage } from './util';
@@ -42,6 +43,10 @@ describe('auto-flag mines on win', function () {
 
     beforeEach(() => {
         eventHandlerStub = jest.fn();
+    });
+
+    afterEach(() => {
+        cleanupGame();
     });
 
     it('should auto-flag all remaining unflagged mines when winning', function () {

--- a/test/win-auto-flag.test.ts
+++ b/test/win-auto-flag.test.ts
@@ -1,4 +1,4 @@
-import { jest, expect } from '@jest/globals';
+import { jest, expect, describe, beforeEach, it } from '@jest/globals';
 import {
     initGame,
     selectSpot,

--- a/test/win-auto-flag.test.ts
+++ b/test/win-auto-flag.test.ts
@@ -15,11 +15,8 @@ import { IGameStorage } from '../src/storage';
 describe('auto-flag mines on win', function () {
     let eventHandlerStub: Mock;
 
-    async function setupGame(
-        gameStorage: IGameStorage,
-        gameOptions: GameOptions,
-    ): Promise<GameState> {
-        await initGame(gameOptions, eventHandlerStub, gameStorage);
+    function setupGame(gameStorage: IGameStorage, gameOptions: GameOptions): GameState {
+        initGame(gameOptions, eventHandlerStub, gameStorage);
         return getGameState();
     }
 
@@ -47,9 +44,9 @@ describe('auto-flag mines on win', function () {
         eventHandlerStub = jest.fn();
     });
 
-    it('should auto-flag all remaining unflagged mines when winning', async function () {
+    it('should auto-flag all remaining unflagged mines when winning', function () {
         // Create a simple 3x3 board with 2 mines
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 3,
             boardHeight: 3,
             numberOfMines: 2,
@@ -97,9 +94,9 @@ describe('auto-flag mines on win', function () {
         }
     });
 
-    it('should auto-flag only unflagged mines when winning with some mines already flagged', async function () {
+    it('should auto-flag only unflagged mines when winning with some mines already flagged', function () {
         // Create a simple 4x4 board with 3 mines
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 4,
             boardHeight: 4,
             numberOfMines: 3,
@@ -151,9 +148,9 @@ describe('auto-flag mines on win', function () {
         }
     });
 
-    it('should only auto-flag mines and not affect non-mine cells', async function () {
+    it('should only auto-flag mines and not affect non-mine cells', function () {
         // Create a simple 4x4 board with 3 mines
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 4,
             boardHeight: 4,
             numberOfMines: 3,
@@ -220,9 +217,9 @@ describe('auto-flag mines on win', function () {
         expect(flaggedNonMineCount).toBe(0);
     });
 
-    it('should set mine counter to 0 after winning', async function () {
+    it('should set mine counter to 0 after winning', function () {
         // Create a simple 3x3 board with 2 mines
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 3,
             boardHeight: 3,
             numberOfMines: 2,
@@ -248,9 +245,9 @@ describe('auto-flag mines on win', function () {
         expect(unflaggedMineCount).toBe(0);
     });
 
-    it('should work correctly with a larger board', async function () {
+    it('should work correctly with a larger board', function () {
         // Create a 5x5 board with 8 mines
-        const gameState = await setupGame(new NonexistentMockGameStorage(), {
+        const gameState = setupGame(new NonexistentMockGameStorage(), {
             boardWidth: 5,
             boardHeight: 5,
             numberOfMines: 8,
@@ -297,7 +294,7 @@ describe('auto-flag mines on win', function () {
         expect(unflaggedMines).toBe(0);
     });
 
-    it('should auto-flag remaining mines when winning via selectAdjacentSpots', async function () {
+    it('should auto-flag remaining mines when winning via selectAdjacentSpots', function () {
         // Create a preset 3x4 board with specific mine positions
         // Board layout:
         //   0 1 2
@@ -355,7 +352,7 @@ describe('auto-flag mines on win', function () {
             spareMineSpot: { x: -1, y: -1 },
         };
 
-        const gameState = await setupGame(new MockGameStorage(presetState), {
+        const gameState = setupGame(new MockGameStorage(presetState), {
             boardWidth: 3,
             boardHeight: 4,
             numberOfMines: 2,
@@ -378,9 +375,6 @@ describe('auto-flag mines on win', function () {
 
         // Use selectAdjacentSpots on a revealed tile to reveal the remaining safe tiles
         selectAdjacentSpots(1, 1);
-
-        // Wait for async operations
-        await Promise.resolve();
 
         // Verify the player has won
         expect(gameState.won).toBe(true);

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "types": ["node", "jest", "cypress", "cypress-real-events"]
+        "types": ["node", "jest"]
     },
-    "include": ["src", "test", "cypress"]
+    "include": ["src", "test"]
 }


### PR DESCRIPTION
Fixes #3.

Replaces recursion approach with iterative approach to allow for boards of greater dimensions. (also tested with 1000x1000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added large-board scalability tests validating flood-fill behavior up to 1000×1000 and ensuring all safe cells are revealed.

* **Bug Fixes**
  * Fixed reveal behavior so hitting a mine consistently reveals the board on loss.

* **Performance & Scalability**
  * Reworked flood-fill to a synchronous, queue-based traversal to prevent stack overflows and improve reliability on very large boards.

* **Chores / CI**
  * Added a code-quality workflow, simplified the test CI job, and adjusted type-checking scripts/configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->