### PR TITLE
fix(COT-18): zoom pinch gesture relative to pinch midpoint

### DIFF
--- a/src/manager/transform.ts
+++ b/src/manager/transform.ts
@@ -74,6 +74,32 @@ export class TransformManager {
         this.adjustBoardTransform(true);
     }
 
+    zoomAtPoint(
+        currMidX: number,
+        currMidY: number,
+        prevMidX: number,
+        prevMidY: number,
+        distanceRatio: number,
+    ) {
+        const oldScale = this._boardTransform.scale;
+        const newScale = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, oldScale * distanceRatio));
+        const actualRatio = newScale / oldScale;
+
+        // Get the current visible center of the board element (post-transform).
+        // vcx = natural_center_x + tx, so (point - vcx) gives element-local offset.
+        const rect = this.boardElem.getBoundingClientRect();
+        const vcx = rect.left + rect.width / 2;
+        const vcy = rect.top + rect.height / 2;
+
+        // Translate so that the content under prevMidpoint moves to currMidpoint
+        // after the scale change, keeping the pinch point stationary in the viewport.
+        this._boardTransform.x += currMidX - vcx - (prevMidX - vcx) * actualRatio;
+        this._boardTransform.y += currMidY - vcy - (prevMidY - vcy) * actualRatio;
+        this._boardTransform.scale = newScale;
+
+        this.adjustBoardTransform(false);
+    }
+
     addEventListener(event: TransformEvent, listener: TransformEventFunction) {
         if (!this.eventListeners.get(event)) {
             this.eventListeners.set(event, []);

--- a/src/manager/transform.ts
+++ b/src/manager/transform.ts
@@ -12,7 +12,7 @@ export const MAX_ZOOM = 2;
 
 // Extra pixels added to the computed pan extent so that zoom gestures near the
 // board edge have room to breathe before hitting the hard boundary.
-const BOUNDS_PADDING = 150;
+const BOUNDS_PADDING = 300;
 
 import type { Bounds } from '../config';
 

--- a/src/manager/transform.ts
+++ b/src/manager/transform.ts
@@ -115,65 +115,41 @@ export class TransformManager {
     }
 
     adjustBoardTransform(useTransition: boolean) {
-        // If bounds are set, clamp x/y to the bounds values.
         if (this.bounds) {
-            let minXAllowed: number, maxXAllowed: number, minYAllowed: number, maxYAllowed: number;
-            // Compute board pixel dimensions based on DOM and use them with viewport to derive allowed translate ranges.
-            // If the scaled board is smaller than the viewport, keep it centered and prevent moving out of view.
-            // If the scaled board is larger than the viewport, allow panning so edges can be reached.
+            // Start from the config hard limits; tighten with dynamic extent if possible.
+            let minX = this.bounds.minX;
+            let maxX = this.bounds.maxX;
+            let minY = this.bounds.minY;
+            let maxY = this.bounds.maxY;
+
             try {
-                let allowedExtentX = 0; // positive number: maximum absolute translate allowed by viewport
-                let allowedExtentY = 0;
-                const boardElem = document.querySelector('#board') as HTMLElement | null;
                 const cellElem = document.querySelector('.box') as HTMLElement | null;
-                if (boardElem && cellElem) {
-                    const rows = boardElem.querySelectorAll('.row');
-                    const rowCount = rows.length || 0;
-                    const colCount = rows[0] ? rows[0].children.length : 0;
+                const rows = document.querySelectorAll('#board .row');
+                if (cellElem && rows.length > 0) {
+                    // getBoundingClientRect reflects the current CSS scale, so these
+                    // dimensions are already in post-transform viewport pixels.
                     const cellRect = cellElem.getBoundingClientRect();
-                    const cellW = cellRect.width || 30;
-                    const cellH = cellRect.height || 30;
-                    const boardWidth = colCount * cellW;
-                    const boardHeight = rowCount * cellH;
-                    const viewportW = window.innerWidth;
-                    const viewportH = window.innerHeight;
-                    const scaledBoardWidth = boardWidth * this._boardTransform.scale;
-                    const scaledBoardHeight = boardHeight * this._boardTransform.scale;
+                    const boardW = (rows[0].children.length || 0) * (cellRect.width || 30);
+                    const boardH = rows.length * (cellRect.height || 30);
 
-                    if (scaledBoardWidth <= viewportW) {
-                        // Board fits horizontally - limit translation so it remains visible centered
-                        allowedExtentX = (viewportW - scaledBoardWidth) / 2 + BOUNDS_PADDING;
-                    } else {
-                        // Board larger horizontally - allow panning so edges can be reached
-                        allowedExtentX = (scaledBoardWidth - viewportW) / 2 + BOUNDS_PADDING;
-                    }
+                    // How far the board center may shift before its edge leaves the
+                    // viewport. The Math.abs handles both "board smaller than viewport"
+                    // and "board larger than viewport" with the same formula.
+                    const extentX = Math.abs(boardW - window.innerWidth) / 2 + BOUNDS_PADDING;
+                    const extentY = Math.abs(boardH - window.innerHeight) / 2 + BOUNDS_PADDING;
 
-                    if (scaledBoardHeight <= viewportH) {
-                        allowedExtentY = (viewportH - scaledBoardHeight) / 2 + BOUNDS_PADDING;
-                    } else {
-                        allowedExtentY = (scaledBoardHeight - viewportH) / 2 + BOUNDS_PADDING;
-                    }
+                    // Intersect dynamic extent with config hard limits.
+                    minX = Math.max(this.bounds.minX, -extentX);
+                    maxX = Math.min(this.bounds.maxX, extentX);
+                    minY = Math.max(this.bounds.minY, -extentY);
+                    maxY = Math.min(this.bounds.maxY, extentY);
                 }
-                minXAllowed = Math.max(this.bounds.minX, -allowedExtentX);
-                maxXAllowed = Math.min(this.bounds.maxX, allowedExtentX);
-                minYAllowed = Math.max(this.bounds.minY, -allowedExtentY);
-                maxYAllowed = Math.min(this.bounds.maxY, allowedExtentY);
             } catch (_e) {
-                // If measurement fails, fall back to using bounds only
-                minXAllowed = this.bounds.minX;
-                maxXAllowed = this.bounds.maxX;
-                minYAllowed = this.bounds.minY;
-                maxYAllowed = this.bounds.maxY;
+                // DOM not ready; config limits unchanged.
             }
 
-            this._boardTransform.x = Math.max(
-                minXAllowed,
-                Math.min(maxXAllowed, this._boardTransform.x),
-            );
-            this._boardTransform.y = Math.max(
-                minYAllowed,
-                Math.min(maxYAllowed, this._boardTransform.y),
-            );
+            this._boardTransform.x = Math.max(minX, Math.min(maxX, this._boardTransform.x));
+            this._boardTransform.y = Math.max(minY, Math.min(maxY, this._boardTransform.y));
         }
 
         const translateRule = `translate(${this._boardTransform.x}px, ${this._boardTransform.y}px)`;
@@ -186,16 +162,8 @@ export class TransformManager {
             }, 10);
         }
 
-        if (this._boardTransform.scale > MIN_ZOOM) {
-            this.triggerEvent('zoom-in');
-        } else {
-            this.triggerEvent('zoom-out-max');
-        }
-        if (this._boardTransform.scale < MAX_ZOOM) {
-            this.triggerEvent('zoom-out');
-        } else {
-            this.triggerEvent('zoom-in-max');
-        }
+        this.triggerEvent(this._boardTransform.scale > MIN_ZOOM ? 'zoom-in' : 'zoom-out-max');
+        this.triggerEvent(this._boardTransform.scale < MAX_ZOOM ? 'zoom-out' : 'zoom-in-max');
 
         (document.querySelector('#x') as HTMLSpanElement).innerText =
             this._boardTransform.x.toString();

--- a/src/manager/transform.ts
+++ b/src/manager/transform.ts
@@ -10,6 +10,10 @@ export type TransformEventFunction = () => void;
 export const MIN_ZOOM = 0.5;
 export const MAX_ZOOM = 2;
 
+// Extra pixels added to the computed pan extent so that zoom gestures near the
+// board edge have room to breathe before hitting the hard boundary.
+const BOUNDS_PADDING = 150;
+
 import type { Bounds } from '../config';
 
 export class TransformManager {
@@ -138,16 +142,16 @@ export class TransformManager {
 
                     if (scaledBoardWidth <= viewportW) {
                         // Board fits horizontally - limit translation so it remains visible centered
-                        allowedExtentX = (viewportW - scaledBoardWidth) / 2;
+                        allowedExtentX = (viewportW - scaledBoardWidth) / 2 + BOUNDS_PADDING;
                     } else {
                         // Board larger horizontally - allow panning so edges can be reached
-                        allowedExtentX = (scaledBoardWidth - viewportW) / 2;
+                        allowedExtentX = (scaledBoardWidth - viewportW) / 2 + BOUNDS_PADDING;
                     }
 
                     if (scaledBoardHeight <= viewportH) {
-                        allowedExtentY = (viewportH - scaledBoardHeight) / 2;
+                        allowedExtentY = (viewportH - scaledBoardHeight) / 2 + BOUNDS_PADDING;
                     } else {
-                        allowedExtentY = (scaledBoardHeight - viewportH) / 2;
+                        allowedExtentY = (scaledBoardHeight - viewportH) / 2 + BOUNDS_PADDING;
                     }
                 }
                 minXAllowed = Math.max(this.bounds.minX, -allowedExtentX);

--- a/src/manager/transform.ts
+++ b/src/manager/transform.ts
@@ -85,8 +85,11 @@ export class TransformManager {
         const newScale = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, oldScale * distanceRatio));
         const actualRatio = newScale / oldScale;
 
-        // Get the current visible center of the board element (post-transform).
-        // vcx = natural_center_x + tx, so (point - vcx) gives element-local offset.
+        // Get the current visible center of this.boardElem in viewport pixels (post-transform).
+        // vcx/vcy are at the current scale, so (point - vcx) is a viewport-scaled offset,
+        // not an element-local/pre-scale offset. Converting to element-local would divide by
+        // oldScale, but that factor cancels with the oldScale inside actualRatio, so the
+        // formula is correct as written directly in viewport-scaled coordinates.
         const rect = this.boardElem.getBoundingClientRect();
         const vcx = rect.left + rect.width / 2;
         const vcy = rect.top + rect.height / 2;

--- a/src/styles/components/zoom.css
+++ b/src/styles/components/zoom.css
@@ -5,4 +5,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
+
+    /* Prevent browser-native pinch-zoom and pan from firing alongside our
+       custom gesture handling. Chrome on Android ignores the viewport
+       user-scalable=no meta tag, so this CSS property is required. */
+    touch-action: none;
 }

--- a/src/subsystem/interaction.ts
+++ b/src/subsystem/interaction.ts
@@ -253,6 +253,13 @@ export function setupInteractionSubsystem(
                 const currentDistance = getDistance(event.touches);
                 const currentMidpoint = getMidpoint(event.touches);
 
+                // Guard against a touchmove arriving without a prior two-finger touchstart
+                // (startDistance would be 0, producing an Infinity ratio).
+                if (startDistance <= 0) {
+                    startDistance = currentDistance;
+                    startMidpoint = currentMidpoint;
+                }
+
                 // Zoom toward the pinch midpoint and pan with midpoint movement
                 transformManager.zoomAtPoint(
                     currentMidpoint.x,

--- a/src/subsystem/interaction.ts
+++ b/src/subsystem/interaction.ts
@@ -208,6 +208,7 @@ export function setupInteractionSubsystem(
 
     let isPinching = false;
     let isMoving = false;
+    let momentumFrame: number | null = null;
     let lastMoveTime = 0;
     let lastTouchX = 0;
     let lastTouchY = 0;
@@ -222,6 +223,11 @@ export function setupInteractionSubsystem(
         (event) => {
             console.log('touch start on zoomable', event.touches);
             if (event.touches.length === 2) {
+                if (momentumFrame !== null) {
+                    cancelAnimationFrame(momentumFrame);
+                    momentumFrame = null;
+                }
+                isMoving = false;
                 startDistance = getDistance(event.touches);
                 startMidpoint = getMidpoint(event.touches);
                 event.preventDefault();
@@ -234,6 +240,10 @@ export function setupInteractionSubsystem(
                     isPinching.toString();
                 return;
             } else if (event.touches.length === 1) {
+                if (momentumFrame !== null) {
+                    cancelAnimationFrame(momentumFrame);
+                    momentumFrame = null;
+                }
                 isMoving = true;
                 lastTouchX = event.touches[0].clientX;
                 lastTouchY = event.touches[0].clientY;
@@ -312,6 +322,7 @@ export function setupInteractionSubsystem(
 
                 if (event.touches.length === 0) {
                     isPinching = false;
+                    isMoving = false;
                     console.log('pinch ended');
                     (document.querySelector('#pinch') as HTMLSpanElement).innerText =
                         isPinching.toString();
@@ -322,7 +333,10 @@ export function setupInteractionSubsystem(
             console.log('isMoving', isMoving);
             if (isMoving) {
                 const momentum = () => {
-                    if (!isMoving) return;
+                    if (!isMoving) {
+                        momentumFrame = null;
+                        return;
+                    }
 
                     touchVelocityX *= touchFriction;
                     touchVelocityY *= touchFriction;
@@ -336,9 +350,10 @@ export function setupInteractionSubsystem(
                     transformManager.adjustBoardTransform(false);
 
                     if (Math.abs(touchVelocityX) > 0.01 || Math.abs(touchVelocityY) > 0.01) {
-                        requestAnimationFrame(momentum);
+                        momentumFrame = requestAnimationFrame(momentum);
                     } else {
                         isMoving = false;
+                        momentumFrame = null;
                     }
                 };
 

--- a/src/subsystem/interaction.ts
+++ b/src/subsystem/interaction.ts
@@ -1,7 +1,7 @@
 import MobileDetect from 'mobile-detect';
 import { GameState } from '../game';
 import { FullscreenManager } from '../manager/fullscreen';
-import { MAX_ZOOM, MIN_ZOOM, TransformManager } from '../manager/transform';
+import { TransformManager } from '../manager/transform';
 import { getPreferenceValue } from '../preferences';
 import { FrontendState } from '..';
 import { toggleQuestionMode } from '../inputMode';
@@ -253,24 +253,16 @@ export function setupInteractionSubsystem(
                 const currentDistance = getDistance(event.touches);
                 const currentMidpoint = getMidpoint(event.touches);
 
-                // Zoom factor based on distance ratio
-                const zoomFactor = currentDistance / startDistance;
+                // Zoom toward the pinch midpoint and pan with midpoint movement
+                transformManager.zoomAtPoint(
+                    currentMidpoint.x,
+                    currentMidpoint.y,
+                    startMidpoint.x,
+                    startMidpoint.y,
+                    currentDistance / startDistance,
+                );
 
-                // Translation based on midpoint movement
-                const newBoardTransform = transformManager.boardTransform;
-                newBoardTransform.x += currentMidpoint.x - startMidpoint.x;
-                newBoardTransform.y += currentMidpoint.y - startMidpoint.y;
-
-                // Apply the zoom and translation
-                newBoardTransform.scale *= zoomFactor;
-                newBoardTransform.scale = Math.max(
-                    MIN_ZOOM,
-                    Math.min(MAX_ZOOM, newBoardTransform.scale),
-                ); // Limit scale between min and max
-                transformManager.boardTransform = newBoardTransform;
-                transformManager.adjustBoardTransform(false);
-
-                // Update the start distance for smooth scaling
+                // Update start values for next frame
                 startDistance = currentDistance;
                 startMidpoint = currentMidpoint;
                 event.preventDefault();

--- a/src/subsystem/interaction.ts
+++ b/src/subsystem/interaction.ts
@@ -226,6 +226,8 @@ export function setupInteractionSubsystem(
                 if (momentumFrame !== null) {
                     cancelAnimationFrame(momentumFrame);
                     momentumFrame = null;
+                    touchVelocityX = 0;
+                    touchVelocityY = 0;
                 }
                 isMoving = false;
                 startDistance = getDistance(event.touches);
@@ -243,6 +245,8 @@ export function setupInteractionSubsystem(
                 if (momentumFrame !== null) {
                     cancelAnimationFrame(momentumFrame);
                     momentumFrame = null;
+                    touchVelocityX = 0;
+                    touchVelocityY = 0;
                 }
                 isMoving = true;
                 lastTouchX = event.touches[0].clientX;
@@ -263,11 +267,20 @@ export function setupInteractionSubsystem(
                 const currentDistance = getDistance(event.touches);
                 const currentMidpoint = getMidpoint(event.touches);
 
+                // Overlapping touches produce distance 0 — skip to avoid NaN.
+                if (currentDistance <= 0) {
+                    event.preventDefault();
+                    return;
+                }
+
                 // Guard against a touchmove arriving without a prior two-finger touchstart
-                // (startDistance would be 0, producing an Infinity ratio).
+                // (startDistance would be 0, producing an Infinity ratio). Initialise and
+                // skip this frame so the next frame has a valid baseline to compare against.
                 if (startDistance <= 0) {
                     startDistance = currentDistance;
                     startMidpoint = currentMidpoint;
+                    event.preventDefault();
+                    return;
                 }
 
                 // Zoom toward the pinch midpoint and pan with midpoint movement


### PR DESCRIPTION
Add TransformManager.zoomAtPoint() using the correct zoom-to-point formula:
tx_new = tx_old + (currMid - vcx) - (prevMid - vcx) * actualRatio
where vcx is the board element's current visible center from getBoundingClientRect().

This keeps the content under the pinch stationary as the user zooms, and also
handles simultaneous panning when the midpoint moves between frames.

https://claude.ai/code/session_01HYAqE2L94qFB49iRUjQpw7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pinch-zoom now keeps content under the gesture stationary while scaling and enforces zoom limits.
  * Panning bounds are applied more consistently, giving more predictable pan limits.
* **Bug Fixes**
  * Guards added against invalid pinch inputs and ensured moving state consistency across gestures.
  * Cancels in-progress momentum animations when new touches begin.
* **Style**
  * Disabled native browser touch gestures for the zoom area to avoid conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->